### PR TITLE
Issue #32: Fix project title typo in .nuspec file

### DIFF
--- a/Microsoft.IO.RecyclableMemoryStream.nuspec
+++ b/Microsoft.IO.RecyclableMemoryStream.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Microsoft.IO.RecyclableMemoryStream</id>
     <version>1.2.0</version>
-    <title>Micrisift.IO.RecyclableMemoryStream</title>
+    <title>Microsoft.IO.RecyclableMemoryStream</title>
     <authors>Ben Watson; Chip Locke</authors>
     <licenseUrl>https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream</projectUrl>


### PR DESCRIPTION
This pull request aims at fixing the following typo:

![micrisift](https://cloud.githubusercontent.com/assets/104481/20462118/0863997c-af14-11e6-8cd5-03ff914d6657.png)