### PR TITLE
Adding optimized manual implementation of WriteByte

### DIFF
--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -620,33 +620,33 @@ namespace Microsoft.IO
         /// <exception cref="ObjectDisposedException">Object has been disposed</exception>
         public override void WriteByte(byte value)
         {
-			this.CheckDisposed();
-			int blockSize = this.memoryManager.BlockSize;
-			int end = this.position + 1;
-			// Check for overflow
-			if (end > MaxStreamLength)
-			{
-				throw new IOException("Maximum capacity exceeded");
-			}
+            this.CheckDisposed();
+            int blockSize = this.memoryManager.BlockSize;
+            int end = this.position + 1;
+            // Check for overflow
+            if (end > MaxStreamLength)
+            {
+                throw new IOException("Maximum capacity exceeded");
+            }
 
-			this.EnsureCapacity(end);
+            this.EnsureCapacity(end);
 
-			if (this.largeBuffer is null)
-			{
-				int block = this.position / blockSize, offset = this.position % blockSize;
+            if (this.largeBuffer is null)
+            {
+                int block = this.position / blockSize, offset = this.position % blockSize;
 
-				byte[] currentBlock = this.blocks[block];
+                byte[] currentBlock = this.blocks[block];
 
-				currentBlock[offset] = value;
-			}
-			else
-			{
-				this.largeBuffer[this.position] = value;
-			}
+                currentBlock[offset] = value;
+            }
+            else
+            {
+                this.largeBuffer[this.position] = value;
+            }
 
-			this.position = end;
-			this.length = Math.Max(this.position, this.length);
-		}
+            this.position = end;
+            this.length = Math.Max(this.position, this.length);
+        }
 
         /// <summary>
         /// Reads a single byte from the current position in the stream.


### PR DESCRIPTION
This replaces the implementation of the WriteByte method with a manual implementation, that doesn't forward calls to Write(byte[]) via a byte[1] field.

Optimization was identified in issue #48 

Benchmark: Writing 1MB using WriteByte (via Benchmark.NET, using x64 only)


|       Method |        Job | Runtime |     Toolchain |     Mean |     Error |    StdDev |
|------------- |----------- |-------- |-------------- |---------:|----------:|----------:|
| WriteByteNew |      Net47 |     Clr |   CsProjnet47 | 24.89 ms | 0.0104 ms | 0.0097 ms |
| WriteByteOld |      Net47 |     Clr |   CsProjnet47 | 56.09 ms | 0.0703 ms | 0.0623 ms |
| WriteByteNew | NetCore1.1 |    Core | .NET Core 1.1 | 31.25 ms | 0.0448 ms | 0.0419 ms |
| WriteByteOld | NetCore1.1 |    Core | .NET Core 1.1 | 61.21 ms | 0.0311 ms | 0.0276 ms |
| WriteByteNew | NetCore2.0 |    Core | .NET Core 2.0 | 21.31 ms | 0.0039 ms | 0.0037 ms |
| WriteByteOld | NetCore2.0 |    Core | .NET Core 2.0 | 50.01 ms | 0.0243 ms | 0.0215 ms |


```
BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.214)
Intel Core i7-6800K CPU 3.40GHz (Skylake), 1 CPU, 12 logical cores and 6 physical cores
Frequency=3326080 Hz, Resolution=300.6542 ns, Timer=TSC
.NET Core SDK=2.1.300-preview2-008065
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  Net47      : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  NetCore1.1 : .NET Core 1.1.5 (Framework 4.6.25815.04), 64bit RyuJIT
  NetCore2.0 : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT

Jit=RyuJit  Platform=X64
```
