### PR TITLE
Convert Enumerable.Sum to a for[each]

### DIFF
--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -183,12 +183,36 @@ namespace Microsoft.IO
         /// <summary>
         /// Number of bytes in large pool not currently in use
         /// </summary>
-        public long LargePoolFreeSize => this.largeBufferFreeSize.Sum();
+        public long LargePoolFreeSize
+        {
+            get
+            {
+                long sum = 0;
+                foreach (long freeSize in this.largeBufferFreeSize)
+                {
+                    sum += freeSize;
+                }
+
+                return sum;
+            }
+        }
 
         /// <summary>
         /// Number of bytes currently in use by streams from the large pool
         /// </summary>
-        public long LargePoolInUseSize => this.largeBufferInUseSize.Sum();
+        public long LargePoolInUseSize
+        {
+            get
+            {
+                long sum = 0;
+                foreach (long inUseSize in this.largeBufferInUseSize)
+                {
+                    sum += inUseSize;
+                }
+
+                return sum;
+            }
+        }
 
         /// <summary>
         /// How many blocks are in the small pool


### PR DESCRIPTION
The compiler can optimize a for loop over an array very well, but cannot optimize LINQ (and LINQ does not have overloads to special handle arrays today). This results in CallVirt methods that cannot be inlined and add additional performance cost (this can be seen in AzProfiler logs internally).