### PR TITLE
Avoid allocation/generation of Guid in RecyclableMemoryStream if ETW tracing is disabled

### DIFF
--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -187,8 +187,12 @@ namespace Microsoft.IO
             : base(emptyArray)
         {
             this.memoryManager = memoryManager;
-            this.id = Guid.NewGuid();
             this.tag = tag;
+
+            if (RecyclableMemoryStreamManager.Events.Writer.IsEnabled())
+            {
+                this.id = Guid.NewGuid();
+            }
 
             if (requestedSize < memoryManager.BlockSize)
             {


### PR DESCRIPTION
Addresses #60 

Only initializes the id field of the RecyclableMemoryStream if ETW tracing is enabled (id is only used for event correlation).

This means that only RecyclableMemoryStreams allocated after ETW is enabled will have a correlation id generated, otherwise it will be Guid.Empty.