### PR TITLE
Add a new WriteTo method that takes offset and count parameters

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2268,7 +2268,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
-        public void WriteToOtherStreamHasEqualsContents()
+        public void WriteToOtherStreamHasEqualContents()
         {
             var stream = this.GetDefaultStream();
             var buffer = this.GetRandomBuffer(100);
@@ -2280,6 +2280,60 @@ namespace Microsoft.IO.UnitTests
             Assert.That(stream2.Length, Is.EqualTo(stream.Length));
             RMSAssert.BuffersAreEqual(buffer, stream2.GetBuffer(), buffer.Length);
         }
+
+        [TestCase(DefaultBlockSize / 2)]
+        [TestCase(DefaultBlockSize * 2)]
+        public void WriteToOtherStreamOffsetCountHasEqualContentsSubStream(int bufferSize)
+        {
+            var stream = this.GetDefaultStream();
+            var buffer = this.GetRandomBuffer(bufferSize);
+            stream.Write(buffer, 0, buffer.Length);
+
+            // force to large buffers if applicable
+            stream.GetBuffer();
+
+            var stream2 = this.GetDefaultStream();
+            int offset = (int)(bufferSize / 2);
+            int length = (int)(bufferSize / 4);
+
+            stream.WriteTo(stream2, offset, length);
+
+            Assert.That(stream2.Length, Is.EqualTo(length));
+            RMSAssert.BuffersAreEqual(buffer, offset, stream2.GetBuffer(), 0, length);
+        }
+
+        [TestCase(DefaultBlockSize / 2)]
+        [TestCase(DefaultBlockSize * 2)]
+        public void WriteToOtherStreamOffsetCountHasEqualContentsFullStream(int bufferSize)
+        {
+            var stream = this.GetDefaultStream();
+            var buffer = this.GetRandomBuffer(bufferSize);
+            stream.Write(buffer, 0, buffer.Length);
+
+            // force to large buffers if applicable
+            stream.GetBuffer();
+
+            var stream2 = this.GetDefaultStream();
+            int offset = 0;
+            int length = buffer.Length;
+
+            stream.WriteTo(stream2, offset, length);
+
+            Assert.That(stream2.Length, Is.EqualTo(length));
+            RMSAssert.BuffersAreEqual(buffer, offset, stream2.GetBuffer(), 0, length);
+        }
+
+        [Test]
+        public void WriteToOtherStreamOffsetCountThrowException()
+        {
+            var stream = this.GetDefaultStream();
+            Assert.Throws<ArgumentNullException>(() => stream.WriteTo(null, 0, (int)stream.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.WriteTo(stream, -1, (int)stream.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.WriteTo(stream, 1, (int)stream.Length));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.WriteTo(stream, 0, (int)stream.Length + 1));
+        }
+
+
         #endregion
 
         #region MaximumStreamCapacityBytes Tests

--- a/docs/Microsoft.IO/RecyclableMemoryStream.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream.md
@@ -31,7 +31,8 @@ public sealed class RecyclableMemoryStream : MemoryStream
 | override [TryGetBuffer](RecyclableMemoryStream/TryGetBuffer.md)(…) | Returns an ArraySegment that wraps a single buffer containing the contents of the stream. |
 | override [Write](RecyclableMemoryStream/Write.md)(…) | Writes the buffer to the stream (2 methods) |
 | override [WriteByte](RecyclableMemoryStream/WriteByte.md)(…) | Writes a single byte to the current position in the stream. |
-| override [WriteTo](RecyclableMemoryStream/WriteTo.md)(…) | Synchronously writes this stream's bytes to the parameter stream. |
+| override [WriteTo](RecyclableMemoryStream/WriteTo.md)(…) | Synchronously writes this stream's bytes to the argument stream. |
+| [WriteTo](RecyclableMemoryStream/WriteTo.md)(…) | Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream. |
 
 ## Protected Members
 

--- a/docs/Microsoft.IO/RecyclableMemoryStream/WriteTo.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream/WriteTo.md
@@ -1,6 +1,6 @@
-# RecyclableMemoryStream.WriteTo method
+# RecyclableMemoryStream.WriteTo method (1 of 2)
 
-Synchronously writes this stream's bytes to the parameter stream.
+Synchronously writes this stream's bytes to the argument stream.
 
 ```csharp
 public override void WriteTo(Stream stream)
@@ -10,9 +10,43 @@ public override void WriteTo(Stream stream)
 | --- | --- |
 | stream | Destination stream |
 
+## Exceptions
+
+| exception | condition |
+| --- | --- |
+| ArgumentNullException | stream is null |
+
 ## Remarks
 
 Important: This does a synchronous write, which may not be desired in some situations
+
+## See Also
+
+* class [RecyclableMemoryStream](../RecyclableMemoryStream.md)
+* namespace [Microsoft.IO](../../Microsoft.IO.RecyclableMemoryStream.md)
+
+---
+
+# RecyclableMemoryStream.WriteTo method (2 of 2)
+
+Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream.
+
+```csharp
+public void WriteTo(Stream stream, int offset, int count)
+```
+
+| parameter | description |
+| --- | --- |
+| stream | Destination stream |
+| offset | Offset in source |
+| count | Number of bytes to write |
+
+## Exceptions
+
+| exception | condition |
+| --- | --- |
+| ArgumentNullException | stream is null |
+| ArgumentOutOfRangeException | Offset is less than 0, or offset + count is beyond this stream's length. |
 
 ## See Also
 

--- a/generatedocs.cmd
+++ b/generatedocs.cmd
@@ -1,0 +1,1 @@
+xmldocmd .\src\bin\Release\netstandard2.1\Microsoft.IO.RecyclableMemoryStream.dll .\docs --obsolete --clean


### PR DESCRIPTION
This adds `WriteTo(Stream stream, int offset, int count)` to allow writing of partial stream to a destination stream.

Resolves #92 