### PR TITLE
Expose internal buffers through GetReadOnlySequence()

### DIFF
--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -485,9 +485,9 @@ namespace Microsoft.IO
 
 #if NETCOREAPP2_1 || NETSTANDARD2_1
         /// <summary>
-        /// Returns a sequence containing the contents the stream.
+        /// Returns a sequence containing the contents of the stream.
         /// </summary>
-        /// <returns>A ReadOnlySequence of bytes.</returns>
+        /// <returns>A ReadOnlySequence of bytes</returns>
         /// <remarks>IMPORTANT: Doing a Write(), Dispose(), or Close() after calling GetReadOnlySequence() invalidates the sequence.</remarks>
         /// <exception cref="ObjectDisposedException">Object has been disposed</exception>
         public ReadOnlySequence<byte> GetReadOnlySequence()


### PR DESCRIPTION
# Problem #
Using RecyclableMemoryStream with other common APIs often requires unnecessary intermediary buffers. Consider something like IncrementalHash.AppendData(). There are two options to hash the contents of the stream:

### Use TryGetBuffer() ###
```csharp
IncrementalHash hash;
RecyclableMemoryStream stream;
// ...
stream.TryGetBuffer(out var buffer);
hash.AppendData(buffer);
```

or 

### Use your own buffer ###
```csharp
IncrementalHash hash;
RecyclableMemoryStream stream;
byte[] buffer;
int count;
// ...
while((count = stream.Read(buffer)) > 0)
    hash.AppendData(buffer, 0, count);
```

While sometimes TryGetBuffer() won't copy the stream contents to a new buffer, it will if the stream has multiple blocks. This costs CPU time, cache evictions, and increased working set.

# Solution #

GetReadOnlySequence() lets us work with APIs accepting arrays or spans without copying.

### Use GetReadOnlySequence() ###
```csharp
IncrementalHash hash;
RecyclableMemoryStream stream;
// ...
foreach(Memory<byte> memory in stream.GetReadOnlySequence())
    hash.AppendData(memory.Span);
```

There are many other uses as well: SequenceReader, Encoder.GetBytes(), reading from a network or file stream, and so on. We can improve performance in all these cases by exposing the stream's buffers directly through GetReadOnlySequence().