### PR TITLE
Remove Task.Run

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2505,6 +2505,32 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        public void CopyToAsyncZeroBlocks()
+        {
+            using (var stream = GetDefaultStream())
+            {
+                var otherStream = GetDefaultStream();
+                stream.CopyToAsync(otherStream);
+                Assert.That(otherStream.Length, Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        public void CopyToAsyncZeroBlocksNonMemoryStream()
+        {
+            using (var stream = GetDefaultStream())
+            {
+                var filename = Path.GetRandomFileName();
+                using (var fileStream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, DefaultBlockSize, FileOptions.Asynchronous))
+                {
+                    stream.CopyToAsync(fileStream).Wait();
+                }
+                var otherBuffer = File.ReadAllBytes(filename);
+                Assert.That(otherBuffer.Length, Is.EqualTo(0));
+            }
+        }
+
+        [Test]
         public void CopyToAsyncOneBlock()
         {
             using (var stream = GetDefaultStream())
@@ -2515,6 +2541,24 @@ namespace Microsoft.IO.UnitTests
                 stream.CopyToAsync(otherStream);
                 Assert.That(otherStream.Length, Is.EqualTo(stream.Length));
                 RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherStream.GetBuffer(), buffer.Length);
+            }
+        }
+
+        [Test]
+        public void CopyToAsyncOneBlockNonMemoryStream()
+        {
+            using (var stream = GetDefaultStream())
+            {
+                var buffer = GetRandomBuffer(DefaultBlockSize);
+                stream.Write(buffer, 0, buffer.Length);
+                var filename = Path.GetRandomFileName();
+                using (var fileStream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, DefaultBlockSize, FileOptions.Asynchronous))
+                {
+                    stream.CopyToAsync(fileStream).Wait();
+                }
+                var otherBuffer = File.ReadAllBytes(filename);
+                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length));
+                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherBuffer, buffer.Length);
             }
         }
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -502,8 +502,17 @@ namespace Microsoft.IO
             }
 
             CheckDisposed();
-            var destinationRMS = destination as MemoryStream;
-            if (destinationRMS != null)
+
+            if (this.length == 0)
+            {
+#if NET45
+                return Task.FromResult(true);
+#else
+                return Task.CompletedTask;
+#endif
+            }
+
+            if (destination is MemoryStream destinationRMS)
             {
                 this.WriteTo(destinationRMS);
 #if NET45
@@ -514,26 +523,34 @@ namespace Microsoft.IO
             }
             else
             {
-                var task = Task.Run(async () =>
+                if (this.largeBuffer == null)
                 {
-                    if (this.largeBuffer == null)
+                    if (this.blocks.Count == 1)
                     {
-                        var bytesRemaining = this.length;
-                        int currentBlock = 0;
-                        while (bytesRemaining > 0)
-                        {
-                            int amountToCopy = Math.Min(this.blocks[currentBlock].Length, bytesRemaining);
-                            await destination.WriteAsync(this.blocks[currentBlock], 0, amountToCopy, cancellationToken);
-                            bytesRemaining -= amountToCopy;
-                            ++currentBlock;
-                        }
+                        return destination.WriteAsync(this.blocks[0], 0, this.length, cancellationToken);
                     }
                     else
                     {
-                        await destination.WriteAsync(this.largeBuffer, 0, this.length, cancellationToken);
+                        return CopyToAsyncImpl();
+
+                        async Task CopyToAsyncImpl()
+                        {
+                            var bytesRemaining = this.length;
+                            int currentBlock = 0;
+                            while (bytesRemaining > 0)
+                            {
+                                int amountToCopy = Math.Min(this.blocks[currentBlock].Length, bytesRemaining);
+                                await destination.WriteAsync(this.blocks[currentBlock], 0, amountToCopy, cancellationToken);
+                                bytesRemaining -= amountToCopy;
+                                ++currentBlock;
+                            }
+                        }
                     }
-                });
-                return task;
+                }
+                else
+                {
+                    return destination.WriteAsync(this.largeBuffer, 0, this.length, cancellationToken);
+                }
             }
         }
 #endif
@@ -615,7 +632,7 @@ namespace Microsoft.IO
         public override byte[] ToArray()
         {
             this.CheckDisposed();
-            
+
             string stack = this.memoryManager.GenerateCallStacks ? Environment.StackTrace : null;
             RecyclableMemoryStreamManager.Events.Writer.MemoryStreamToArray(this.id, this.tag, stack, this.length);
 
@@ -1053,9 +1070,9 @@ namespace Microsoft.IO
                 stream.Write(this.largeBuffer, offset, count);
             }
         }
-#endregion
+        #endregion
 
-#region Helper Methods
+        #region Helper Methods
         private bool Disposed => Interlocked.Read(ref this.disposedState) != 0;
 
         [MethodImpl((MethodImplOptions)256)]
@@ -1216,6 +1233,6 @@ namespace Microsoft.IO
 
             this.largeBuffer = null;
         }
-#endregion
+        #endregion
     }
 }


### PR DESCRIPTION
This PR removes `Task.Run` from `CopyToAsync`.

To keep form creating the async state machine, only if more than one block exists, the async state machine will be created. This happens with the known [costs and benefits of eliding async](https://blog.stephencleary.com/2016/12/eliding-async-await.html).

Add more tests for more coverage.