### PR TITLE
Fix CopyToAsync to start from current position

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2490,17 +2490,19 @@ namespace Microsoft.IO.UnitTests
             }            
         }
 
-        [Test]
-        public void CopyToAsyncSmallerThanBlock()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncSmallerThanBlock(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize / 2);
                 stream.Write(buffer, 0, buffer.Length);
+                stream.Position = offset;
                 var otherStream = GetDefaultStream();
                 stream.CopyToAsync(otherStream);
-                Assert.That(stream.Length, Is.EqualTo(otherStream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherStream.GetBuffer(), buffer.Length);
+                Assert.That(otherStream.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherStream.GetBuffer(), buffer.Length - offset);
             }
         }
 
@@ -2530,101 +2532,113 @@ namespace Microsoft.IO.UnitTests
             }
         }
 
-        [Test]
-        public void CopyToAsyncOneBlock()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncOneBlock(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize);
                 stream.Write(buffer, 0, buffer.Length);
+                stream.Position = offset;
                 var otherStream = GetDefaultStream();
                 stream.CopyToAsync(otherStream);
-                Assert.That(otherStream.Length, Is.EqualTo(stream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherStream.GetBuffer(), buffer.Length);
+                Assert.That(otherStream.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherStream.GetBuffer(), buffer.Length - offset);
             }
         }
 
-        [Test]
-        public void CopyToAsyncOneBlockNonMemoryStream()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncOneBlockNonMemoryStream(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize);
                 stream.Write(buffer, 0, buffer.Length);
+                stream.Position = offset;
                 var filename = Path.GetRandomFileName();
                 using (var fileStream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, DefaultBlockSize, FileOptions.Asynchronous))
                 {
                     stream.CopyToAsync(fileStream).Wait();
                 }
                 var otherBuffer = File.ReadAllBytes(filename);
-                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherBuffer, buffer.Length);
+                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherBuffer, buffer.Length - offset);
             }
         }
 
-        [Test]
-        public void CopyToAsyncMultipleBlocks()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncMultipleBlocks(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize * 25);
                 stream.Write(buffer, 0, buffer.Length);
+                stream.Position = offset;
                 var otherStream = GetDefaultStream();
                 stream.CopyToAsync(otherStream);
-                Assert.That(otherStream.Length, Is.EqualTo(stream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherStream.GetBuffer(), buffer.Length);
+                Assert.That(otherStream.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherStream.GetBuffer(), buffer.Length - offset);
             }
         }
 
-        [Test]
-        public void CopyToAsyncMultipleBlocksNonMemoryStream()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncMultipleBlocksNonMemoryStream(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize * 25);
                 stream.Write(buffer, 0, buffer.Length);
+                stream.Position = offset;
                 var filename = Path.GetRandomFileName();
                 using (var fileStream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, DefaultBlockSize, FileOptions.Asynchronous))
                 {
                     stream.CopyToAsync(fileStream).Wait();
                 }
                 var otherBuffer = File.ReadAllBytes(filename);
-                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherBuffer, buffer.Length);
+                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherBuffer, buffer.Length - offset);
             }
         }
 
-        [Test]
-        public void CopyToAsyncLargeBuffer()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncLargeBuffer(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize * 25);
                 stream.Write(buffer, 0, buffer.Length);
                 var otherStream = GetDefaultStream();
+                stream.Position = offset;
                 stream.GetBuffer();
                 stream.CopyToAsync(otherStream);
-                Assert.That(otherStream.Length, Is.EqualTo(stream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherStream.GetBuffer(), buffer.Length);
+                Assert.That(otherStream.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherStream.GetBuffer(), buffer.Length - offset);
             }
         }
 
-        [Test]
-        public void CopyToAsyncLargeBufferNonMemoryStream()
+        [TestCase(0)]
+        [TestCase(100)]
+        public void CopyToAsyncLargeBufferNonMemoryStream(int offset)
         {
             using (var stream = GetDefaultStream())
             {
                 var buffer = GetRandomBuffer(DefaultBlockSize * 25);
                 stream.Write(buffer, 0, buffer.Length);
                 stream.GetBuffer();
+                stream.Position = offset;
                 var filename = Path.GetRandomFileName();
                 using (var fileStream = new FileStream(filename, FileMode.Create, FileAccess.Write))
                 {
                     stream.CopyToAsync(fileStream).Wait();
                 }
                 var otherBuffer = File.ReadAllBytes(filename);
-                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length));
-                RMSAssert.BuffersAreEqual(stream.GetBuffer(), otherBuffer, buffer.Length);
+                Assert.That(otherBuffer.Length, Is.EqualTo(stream.Length - offset));
+                RMSAssert.BuffersAreEqual(new ReadOnlySpan<byte>(stream.GetBuffer(), offset, buffer.Length - offset), otherBuffer, buffer.Length - offset);
             }
         }
         #endregion

--- a/docs/Microsoft.IO/RecyclableMemoryStream.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream.md
@@ -19,7 +19,7 @@ public sealed class RecyclableMemoryStream : MemoryStream
 | override [Length](RecyclableMemoryStream/Length.md) { get; } | Gets the number of bytes written to this stream. |
 | override [Position](RecyclableMemoryStream/Position.md) { get; set; } | Gets the current position in the stream |
 | override [Close](RecyclableMemoryStream/Close.md)() | Equivalent to Dispose |
-| override [CopyToAsync](RecyclableMemoryStream/CopyToAsync.md)(…) | Asynchronously reads all the bytes from the current stream and writes them to another stream. |
+| override [CopyToAsync](RecyclableMemoryStream/CopyToAsync.md)(…) | Asynchronously reads all the bytes from the current position in this stream and writes them to another stream. |
 | override [GetBuffer](RecyclableMemoryStream/GetBuffer.md)() | Returns a single buffer containing the contents of the stream. The buffer may be longer than the stream length. |
 | [GetReadOnlySequence](RecyclableMemoryStream/GetReadOnlySequence.md)() | Returns a sequence containing the contents of the stream. |
 | override [Read](RecyclableMemoryStream/Read.md)(…) | Reads from the current position into the provided buffer (2 methods) |

--- a/docs/Microsoft.IO/RecyclableMemoryStream/CopyToAsync.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream/CopyToAsync.md
@@ -1,6 +1,6 @@
 # RecyclableMemoryStream.CopyToAsync method
 
-Asynchronously reads all the bytes from the current stream and writes them to another stream.
+Asynchronously reads all the bytes from the current position in this stream and writes them to another stream.
 
 ```csharp
 public override Task CopyToAsync(Stream destination, int bufferSize, 
@@ -11,7 +11,7 @@ public override Task CopyToAsync(Stream destination, int bufferSize,
 | --- | --- |
 | destination | The stream to which the contents of the current stream will be copied. |
 | bufferSize | This parameter is ignored. |
-| cancellationToken | This parameter is ignored. |
+| cancellationToken | The token to monitor for cancellation requests. |
 
 ## Return Value
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -485,7 +485,7 @@ namespace Microsoft.IO
         }
 
 #if !NET40
-        /// <summary>Asynchronously reads all the bytes from the current stream and writes them to another stream.</summary>
+        /// <summary>Asynchronously reads all the bytes from the current position in this stream and writes them to another stream.</summary>
         /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
         /// <param name="bufferSize">This parameter is ignored.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>


### PR DESCRIPTION
Issue #115 points out that `CopyToAsync` should start from the current stream position, not 0. Looking at the `MemoryStream` code, I confirm this.

This PR corrects this oversight in all code paths, updates the unit tests to catch this, and regenerates documentation to make this clear.