### PR TITLE
Add netstandard2.0 target

### DIFF
--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;netstandard2.1;net40;net45;net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;netstandard2.1;net40;net45;net46;netcoreapp2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.IO.RecyclableMemoryStream.xml</DocumentationFile>
     <!-- NuGet properties -->


### PR DESCRIPTION
Add netstandard2.0 target.

By having only netstandard1.4 and netstandard2.1, some crucial functionality was missing for anyone using this library in a netstandard2.0 project. Specifically: `Close` and `GetBuffer` would have non-obvious behavior because they couldn't be overridden in netstandard1.4. 

Note: it's likely that the next major version of RMS will remove netstandard1.4 and net40.