### PR TITLE
Remove support for net45, net46; bump min version to net462

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Microsoft.IO.RecyclableMemoryStream is a MemoryStream replacement that offers su
 
 At least MSBuild 15 is required to build the code. You get this with Visual Studio 2017.
 
-Build targets in v2 are: net45, net46, netstandard2.0, netstandard2.1, and netcoreapp2.1 (net40 and netstandard1.4 were deprecated).
+Build targets in v2 are: net462, netstandard2.0, netstandard2.1, and netcoreapp2.1 (net40, net45, net46 and netstandard1.4 were deprecated).
 
 
 

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net45;net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;netcoreapp2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.IO.RecyclableMemoryStream.xml</DocumentationFile>
     <!-- NuGet properties -->

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -557,21 +557,13 @@ namespace Microsoft.IO
 
             if (this.length == 0)
             {
-#if NET45
-                return Task.FromResult(true);
-#else
                 return Task.CompletedTask;
-#endif
             }
 
             if (destination is MemoryStream destinationRMS)
             {
                 this.WriteTo(destinationRMS, this.position, this.length - this.position);
-#if NET45
-                return Task.FromResult(true);
-#else
                 return Task.CompletedTask;
-#endif
             }
             else
             {
@@ -672,11 +664,7 @@ namespace Microsoft.IO
         /// <returns>Always returns true.</returns>
         /// <remarks>GetBuffer has no failure modes (it always returns something, even if it's an empty buffer), therefore this method
         /// always returns a valid ArraySegment to the same buffer returned by GetBuffer.</remarks>
-#if NET45
-        public bool TryGetBuffer(out ArraySegment<byte> buffer)  
-#else
         public override bool TryGetBuffer(out ArraySegment<byte> buffer)
-#endif
         {
             this.CheckDisposed();
             Debug.Assert(this.length <= Int32.MaxValue);


### PR DESCRIPTION
.NET 4.6.2 is the minimum supported version of .NET Framework. See [here](https://docs.microsoft.com/en-us/lifecycle/faq/dotnet-framework) for more information on the .NET lifecycle.