### PR TITLE
Unseal RecyclableMemoryStream to enable extending/overriding methods

### DIFF
--- a/docs/Microsoft.IO/RecyclableMemoryStream.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream.md
@@ -3,7 +3,7 @@
 MemoryStream implementation that deals with pooling and managing memory streams which use potentially large buffers.
 
 ```csharp
-public sealed class RecyclableMemoryStream : MemoryStream
+public class RecyclableMemoryStream : MemoryStream
 ```
 
 ## Public Members

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -85,7 +85,7 @@ namespace Microsoft.IO
     /// it cannot grow beyond the limits of the maximum allowable array size.
     /// </para>
     /// </remarks>
-    public sealed class RecyclableMemoryStream : MemoryStream
+    public class RecyclableMemoryStream : MemoryStream
     {
         private static readonly byte[] emptyArray = new byte[0];
 


### PR DESCRIPTION
I found this succinct explanation for why this class may be marked as sealed:
> https://stackoverflow.com/a/52907478/354130
> 
> Marking a class as `Sealed` prevents tampering of important classes that can compromise security, or affect performance.
>
> Many times, sealing a class also makes sense when one is designing a utility class with fixed behaviour, which we don't want to change.

However, I'd like to extend this class to create a `ReadOnlyStream` and utilize the same properties as a normal `Stream`

---

Fixes #136 