### PR TITLE
Upgrade GetReadOnlySequence to work with Multi-Gigabyte streams

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2859,7 +2859,6 @@ namespace Microsoft.IO.UnitTests
             Assert.That(stream.Length, Is.EqualTo(startingLength + 1));
         }
 
-#if NETCOREAPP2_1 || NETSTANDARD2_1
         [Test]
         public void VeryLargeStream_GetReadOnlySequence()
         {
@@ -2869,9 +2868,15 @@ namespace Microsoft.IO.UnitTests
             {
                 stream.Write(buffer);
             }
-            Assert.Throws<InvalidOperationException>(() => stream.GetReadOnlySequence());
+            
+            var sequence = new SequenceReader<byte>(stream.GetReadOnlySequence());
+            Assert.That(sequence.Length, Is.EqualTo(stream.Length));
+
+            while (sequence.Remaining != 0)
+            {
+                Assert.That(sequence.IsNext(buffer, true), Is.True);
+            }
         }
-#endif
 
         private RecyclableMemoryStream GetMultiGBStream()
         {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.IO.RecyclableMemoryStream.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>Full</DebugType> <!-- NUnit in VS2017 needs this instead of the new slimmer PDBs -->
   </PropertyGroup>
   <ItemGroup>

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -760,26 +760,19 @@ namespace Microsoft.IO
 
             if (this.blocks.Count == 1)
             {
-            AssertLengthIsSmall();
+                AssertLengthIsSmall();
                 return new ReadOnlySequence<byte>(this.blocks[0], 0, (int)this.length);
-            }
-
-            if (this.length > RecyclableMemoryStreamManager.MaxArrayLength)
-            {
-                throw new InvalidOperationException($"Cannot return a ReadOnlySequence larger than {RecyclableMemoryStreamManager.MaxArrayLength}, but stream length is {this.length}.");
             }
 
             BlockSegment first = new BlockSegment(this.blocks[0]);
             BlockSegment last = first;
-
             
             for (int blockIdx = 1; blockIdx < blocks.Count; blockIdx++)
             {
                 last = last.Append(this.blocks[blockIdx]);
             }
 
-            Debug.Assert(this.length <= Int32.MaxValue);
-            return new ReadOnlySequence<byte>(first, 0, last, (int)this.length - (int)last.RunningIndex);
+            return new ReadOnlySequence<byte>(first, 0, last, (int)(this.length - last.RunningIndex));
         }
 
         private sealed class BlockSegment : ReadOnlySequenceSegment<byte>


### PR DESCRIPTION
No need to limit it to 2GB streams. 

Changed the target framework of the unit test project to .Net Core 3.1 so we could use SequenceReader in unit tests.