### PR TITLE
Add WriteTo(byte[]....) method overloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Removed build targets for net40, net45, net46, and netstandard1.4. Added net462.
 * Removed use of `Interlocked` methods when checking whether the stream is disposed. Concurrent use of streams is not supported.
 * Refactored .NET events to match the information payloads of the ETW events.
+* New method overloads of `WriteTo` that allow you write the contents of the stream directly to another `byte[]` buffer.
 * Reformatted all code documentation to be more readable.
 
 # Version 1.4.0

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -921,8 +921,6 @@ namespace Microsoft.IO
             return amountRead;
         }
 
-
-
 #if NETCOREAPP2_1 || NETSTANDARD2_1
         /// <summary>
         /// Reads from the current position into the provided buffer
@@ -970,7 +968,6 @@ namespace Microsoft.IO
             streamPosition += amountRead;
             return amountRead;
         }
-        
 #endif
         
         /// <summary>


### PR DESCRIPTION
These methods just add yet more flexibility in getting data out of the stream without resorting to `GetBuffer` calls.