### PR TITLE
Prepare 2.0 release: Fix typos, increment versions

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -3018,7 +3018,7 @@ namespace Microsoft.IO.UnitTests
         public void VeryLargeStream_GetBufferThrows()
         {
             var stream = GetMultiGBStream();
-            Assert.Throws<InvalidOperationException>(() => stream.GetBuffer());
+            Assert.Throws<OutOfMemoryException>(() => stream.GetBuffer());
         }
 
         [Test]

--- a/docs/Microsoft.IO/RecyclableMemoryStream.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream.md
@@ -38,7 +38,7 @@ public sealed class RecyclableMemoryStream : MemoryStream, IBufferWriter<byte>
 | override [Write](RecyclableMemoryStream/Write.md)(…) | Writes the buffer to the stream (2 methods) |
 | override [WriteByte](RecyclableMemoryStream/WriteByte.md)(…) | Writes a single byte to the current position in the stream. |
 | override [WriteTo](RecyclableMemoryStream/WriteTo.md)(…) | Synchronously writes this stream's bytes to the argument stream. |
-| [WriteTo](RecyclableMemoryStream/WriteTo.md)(…) | Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream. (2 methods) |
+| [WriteTo](RecyclableMemoryStream/WriteTo.md)(…) | Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream. (5 methods) |
 
 ## Protected Members
 

--- a/docs/Microsoft.IO/RecyclableMemoryStream/WriteTo.md
+++ b/docs/Microsoft.IO/RecyclableMemoryStream/WriteTo.md
@@ -1,4 +1,34 @@
-# RecyclableMemoryStream.WriteTo method (1 of 3)
+# RecyclableMemoryStream.WriteTo method (1 of 6)
+
+Writes bytes from the current stream to a destination `byte` array
+
+```csharp
+public void WriteTo(byte[] buffer)
+```
+
+| parameter | description |
+| --- | --- |
+| buffer | Target buffer |
+
+## Exceptions
+
+| exception | condition |
+| --- | --- |
+| ArgumentNullException | `buffer` is null |
+| ObjectDisposedException | Object has been disposed |
+
+## Remarks
+
+The entire stream is written to the target array.
+
+## See Also
+
+* class [RecyclableMemoryStream](../RecyclableMemoryStream.md)
+* namespace [Microsoft.IO](../../Microsoft.IO.RecyclableMemoryStream.md)
+
+---
+
+# RecyclableMemoryStream.WriteTo method (2 of 6)
 
 Synchronously writes this stream's bytes to the argument stream.
 
@@ -15,6 +45,7 @@ public override void WriteTo(Stream stream)
 | exception | condition |
 | --- | --- |
 | ArgumentNullException | stream is null |
+| ObjectDisposedException | Object has been disposed |
 
 ## Remarks
 
@@ -27,7 +58,36 @@ Important: This does a synchronous write, which may not be desired in some situa
 
 ---
 
-# RecyclableMemoryStream.WriteTo method (2 of 3)
+# RecyclableMemoryStream.WriteTo method (3 of 6)
+
+Writes bytes from the current stream to a destination `byte` array
+
+```csharp
+public void WriteTo(byte[] buffer, long offset, long count)
+```
+
+| parameter | description |
+| --- | --- |
+| buffer | Target buffer |
+| offset | Offset in the source stream, from which to start |
+| count | Number of bytes to write |
+
+## Exceptions
+
+| exception | condition |
+| --- | --- |
+| ArgumentNullException | `buffer` is null |
+| ArgumentOutOfRangeException | Offset is less than 0, or offset + count is beyond this stream's length. |
+| ObjectDisposedException | Object has been disposed |
+
+## See Also
+
+* class [RecyclableMemoryStream](../RecyclableMemoryStream.md)
+* namespace [Microsoft.IO](../../Microsoft.IO.RecyclableMemoryStream.md)
+
+---
+
+# RecyclableMemoryStream.WriteTo method (4 of 6)
 
 Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream.
 
@@ -47,6 +107,7 @@ public void WriteTo(Stream stream, int offset, int count)
 | --- | --- |
 | ArgumentNullException | stream is null |
 | ArgumentOutOfRangeException | Offset is less than 0, or offset + count is beyond this stream's length. |
+| ObjectDisposedException | Object has been disposed |
 
 ## See Also
 
@@ -55,7 +116,7 @@ public void WriteTo(Stream stream, int offset, int count)
 
 ---
 
-# RecyclableMemoryStream.WriteTo method (3 of 3)
+# RecyclableMemoryStream.WriteTo method (5 of 6)
 
 Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream.
 
@@ -75,6 +136,38 @@ public void WriteTo(Stream stream, long offset, long count)
 | --- | --- |
 | ArgumentNullException | stream is null |
 | ArgumentOutOfRangeException | Offset is less than 0, or offset + count is beyond this stream's length. |
+| ObjectDisposedException | Object has been disposed |
+
+## See Also
+
+* class [RecyclableMemoryStream](../RecyclableMemoryStream.md)
+* namespace [Microsoft.IO](../../Microsoft.IO.RecyclableMemoryStream.md)
+
+---
+
+# RecyclableMemoryStream.WriteTo method (6 of 6)
+
+Writes bytes from the current stream to a destination `byte` array
+
+```csharp
+public void WriteTo(byte[] buffer, long offset, long count, int targetOffset)
+```
+
+| parameter | description |
+| --- | --- |
+| buffer | Target buffer |
+| offset | Offset in the source stream, from which to start |
+| count | Number of bytes to write |
+| targetOffset | Offset in the target byte array to start writing |
+
+## Exceptions
+
+| exception | condition |
+| --- | --- |
+| ArgumentNullException | `buffer` is null |
+| ArgumentOutOfRangeException | Offset is less than 0, or offset + count is beyond this stream's length. |
+| ArgumentOutOfRangeException | targetOffset is less than 0, or targetOffset + count is beyond the target buffer's length. |
+| ObjectDisposedException | Object has been disposed |
 
 ## See Also
 

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.IO.RecyclableMemoryStream.xml</DocumentationFile>
     <!-- NuGet properties -->
     <PackageId>Microsoft.IO.RecyclableMemoryStream</PackageId>
-    <PackageVersion>1.4.0</PackageVersion>
+    <PackageVersion>2.0.0</PackageVersion>
     <Title>Microsoft.IO.RecyclableMemoryStream</Title>
     <Authors>Microsoft</Authors>
     <Description>A pooled MemoryStream allocator to decrease GC load and improve performance on highly scalable systems.</Description>

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -1340,7 +1340,7 @@ namespace Microsoft.IO
         /// </summary>
         /// <param name="buffer">Target buffer</param>
         /// <remarks>The entire stream is written to the target array.</remarks>
-        //// <exception cref="ArgumentNullException"><c>buffer</c> is null</exception>
+        /// <exception cref="ArgumentNullException"><c>buffer</c> is null</exception>
         /// <exception cref="ObjectDisposedException">Object has been disposed</exception>
         public void WriteTo(byte[] buffer)
         {


### PR DESCRIPTION
* Incremented version to 2.0
* Fixed a faulty unit test that hadn't udpated its expected exception correctly
* Fixed a typo in an XML comment
* Re-generated documents
