### PR TITLE
Fix integer overflow bug in RoundToLargeBufferSize

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -3596,6 +3596,19 @@ namespace Microsoft.IO.UnitTests
             }
         }
 
+        // Issue #171 - Infinite Loop when particular values are chosen causing an int overflow during
+        // validation of buffer sizes.
+        // https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/issues/171
+        [Test, Timeout(10000)]
+        public void InvalidLargeBufferSizeDoesNotCauseOverflow()
+        {
+            const int BlockSize = 128;
+            const int LargeBufferMultiple = 1024;
+            const int MaxBufferSize = int.MaxValue;
+
+            Assert.Throws<ArgumentException>(()=>new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize, this.UseExponentialLargeBuffer) { AggressiveBufferReturn = this.AggressiveBufferRelease });
+        }
+
         [Test]
         public override void RequestTooLargeBufferAdjustsInUseCounter()
         {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -5,8 +5,8 @@
     <DebugType>Full</DebugType> <!-- NUnit in VS2017 needs this instead of the new slimmer PDBs -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -457,7 +457,7 @@ namespace Microsoft.IO
         {
             if (this.UseExponentialLargeBuffer)
             {
-                int pow = 1;
+                long pow = 1;
                 while (this.LargeBufferMultiple * pow < requiredSize)
                 {
                     pow <<= 1;


### PR DESCRIPTION
Resolve #171 

This fixes an integer overflow problem that occurs now that sizes can be `long` values. It adds a test that verifies the issue is fixed and upgrades the NUnit packages in order to use the `Timeout` attribute.