### PR TITLE
Avoid enumerator allocations

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.IO.UnitTests
     using System.Buffers;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
@@ -191,7 +192,7 @@ namespace Microsoft.IO.UnitTests
             buffers[0] = memMgr.GetBlock();
             buffers[1] = new byte[memMgr.BlockSize + 1];
             buffers[2] = memMgr.GetBlock();
-            Assert.Throws<ArgumentException>(() => memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty));
+            Assert.Throws<ArgumentException>(() => memMgr.ReturnBlocks(buffers.ToList(), Guid.Empty, string.Empty));
         }
 
         [Test]
@@ -241,7 +242,7 @@ namespace Microsoft.IO.UnitTests
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
 
             // All but one buffer should be returned to pool
-            memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty);
+            memMgr.ReturnBlocks(buffers.ToList(), Guid.Empty, string.Empty);
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.MaximumFreeSmallPoolBytes));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
@@ -263,7 +264,7 @@ namespace Microsoft.IO.UnitTests
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
 
-            memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty);
+            memMgr.ReturnBlocks(buffers.ToList(), Guid.Empty, string.Empty);
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -568,7 +568,7 @@ namespace Microsoft.IO
         /// <param name="tag">The tag of the stream returning these blocks, for logging if necessary.</param>
         /// <exception cref="ArgumentNullException"><paramref name="blocks"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="blocks"/> contains buffers that are the wrong size (or null) for this memory manager.</exception>
-        internal void ReturnBlocks(ICollection<byte[]> blocks, Guid id, string tag)
+        internal void ReturnBlocks(List<byte[]> blocks, Guid id, string tag)
         {
             if (blocks == null)
             {


### PR DESCRIPTION
While small, it's easy to avoid the allocations by using the concrete type instead of `ICollection`.