### PR TITLE
Add GetStream overrides for ReadOnlyMemory<byte>

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2476,6 +2476,31 @@ namespace Microsoft.IO.UnitTests
             RMSAssert.BuffersAreEqual(buffer.Span, stream.GetBuffer(), buffer.Length);
             Assert.That(buffer, Is.Not.SameAs(stream.GetBuffer()));
         }
+
+        [Test]
+        public void GetStreamWithReadOnlyMemoryBuffer()
+        {
+            var memMgr = this.GetMemoryManager();
+            var buffer = new ReadOnlyMemory<byte>(this.GetRandomBuffer(1000));
+            var bufferSlice = buffer.Slice(1);
+            var tag = "MyTag";
+
+            var stream = memMgr.GetStream(tag, bufferSlice) as RecyclableMemoryStream;
+            RMSAssert.BuffersAreEqual(bufferSlice.Span, stream.GetBuffer(), bufferSlice.Length);
+            Assert.That(bufferSlice, Is.Not.SameAs(stream.GetBuffer()));
+            Assert.That(stream.Tag, Is.EqualTo(tag));
+        }
+
+        [Test]
+        public void GetStreamWithOnlyReadOnlyMemoryBuffer()
+        {
+            var memMgr = this.GetMemoryManager();
+            var buffer = new ReadOnlyMemory<byte>(this.GetRandomBuffer(1000));
+
+            var stream = memMgr.GetStream(buffer) as RecyclableMemoryStream;
+            RMSAssert.BuffersAreEqual(buffer.Span, stream.GetBuffer(), buffer.Length);
+            Assert.That(buffer, Is.Not.SameAs(stream.GetBuffer()));
+        }
         #endregion
 
         #region WriteTo tests

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2453,6 +2453,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Obsolete("GetStream(Memory<byte>) is obsolete.")]
         public void GetStreamWithMemoryBuffer()
         {
             var memMgr = this.GetMemoryManager();
@@ -2467,6 +2468,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Obsolete("GetStream(Memory<byte>) is obsolete.")]
         public void GetStreamWithOnlyMemoryBuffer()
         {
             var memMgr = this.GetMemoryManager();
@@ -2478,26 +2480,26 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
-        public void GetStreamWithReadOnlyMemoryBuffer()
+        public void GetStreamWithReadOnlySpan()
         {
             var memMgr = this.GetMemoryManager();
             var buffer = new ReadOnlyMemory<byte>(this.GetRandomBuffer(1000));
             var bufferSlice = buffer.Slice(1);
             var tag = "MyTag";
 
-            var stream = memMgr.GetStream(tag, bufferSlice) as RecyclableMemoryStream;
+            var stream = memMgr.GetStream(tag, bufferSlice.Span) as RecyclableMemoryStream;
             RMSAssert.BuffersAreEqual(bufferSlice.Span, stream.GetBuffer(), bufferSlice.Length);
             Assert.That(bufferSlice, Is.Not.SameAs(stream.GetBuffer()));
             Assert.That(stream.Tag, Is.EqualTo(tag));
         }
 
         [Test]
-        public void GetStreamWithOnlyReadOnlyMemoryBuffer()
+        public void GetStreamWithOnlyReadOnlySpan()
         {
             var memMgr = this.GetMemoryManager();
             var buffer = new ReadOnlyMemory<byte>(this.GetRandomBuffer(1000));
 
-            var stream = memMgr.GetStream(buffer) as RecyclableMemoryStream;
+            var stream = memMgr.GetStream(buffer.Span) as RecyclableMemoryStream;
             RMSAssert.BuffersAreEqual(buffer.Span, stream.GetBuffer(), buffer.Length);
             Assert.That(buffer, Is.Not.SameAs(stream.GetBuffer()));
         }

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -879,6 +879,7 @@ namespace Microsoft.IO
         /// <param name="tag">A tag which can be used to track the source of the stream.</param>
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
+        [Obsolete("Use the ReadOnlySpan<byte> version of this method instead.")]
         public MemoryStream GetStream(Guid id, string tag, Memory<byte> buffer)
         {
             RecyclableMemoryStream stream = null;
@@ -905,13 +906,13 @@ namespace Microsoft.IO
         /// <param name="tag">A tag which can be used to track the source of the stream.</param>
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
-        public MemoryStream GetStream(Guid id, string tag, ReadOnlyMemory<byte> buffer)
+        public MemoryStream GetStream(Guid id, string tag, ReadOnlySpan<byte> buffer)
         {
             RecyclableMemoryStream stream = null;
             try
             {
                 stream = new RecyclableMemoryStream(this, id, tag, buffer.Length);
-                stream.Write(buffer.Span);
+                stream.Write(buffer);
                 stream.Position = 0;
                 return stream;
             }
@@ -929,6 +930,7 @@ namespace Microsoft.IO
         /// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
+        [Obsolete("Use the ReadOnlySpan<byte> version of this method instead.")]
         public MemoryStream GetStream(Memory<byte> buffer)
         {
             return GetStream(null, buffer);
@@ -941,7 +943,7 @@ namespace Microsoft.IO
         /// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
-        public MemoryStream GetStream(ReadOnlyMemory<byte> buffer)
+        public MemoryStream GetStream(ReadOnlySpan<byte> buffer)
         {
             return GetStream(null, buffer);
         }
@@ -954,6 +956,7 @@ namespace Microsoft.IO
         /// <param name="tag">A tag which can be used to track the source of the stream.</param>
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
+        [Obsolete("Use the ReadOnlySpan<byte> version of this method instead.")]
         public MemoryStream GetStream(string tag, Memory<byte> buffer)
         {
             return GetStream(Guid.NewGuid(), tag, buffer);
@@ -967,7 +970,7 @@ namespace Microsoft.IO
         /// <param name="tag">A tag which can be used to track the source of the stream.</param>
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
-        public MemoryStream GetStream(string tag, ReadOnlyMemory<byte> buffer)
+        public MemoryStream GetStream(string tag, ReadOnlySpan<byte> buffer)
         {
             return GetStream(Guid.NewGuid(), tag, buffer);
         }

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -897,6 +897,32 @@ namespace Microsoft.IO
         }
 
         /// <summary>
+        /// Retrieve a new <c>MemoryStream</c> object with the given tag and with contents copied from the provided
+        /// buffer. The provided buffer is not wrapped or used after construction.
+        /// </summary>
+        /// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+        /// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+        /// <param name="tag">A tag which can be used to track the source of the stream.</param>
+        /// <param name="buffer">The byte buffer to copy data from.</param>
+        /// <returns>A <c>MemoryStream</c>.</returns>
+        public MemoryStream GetStream(Guid id, string tag, ReadOnlyMemory<byte> buffer)
+        {
+            RecyclableMemoryStream stream = null;
+            try
+            {
+                stream = new RecyclableMemoryStream(this, id, tag, buffer.Length);
+                stream.Write(buffer.Span);
+                stream.Position = 0;
+                return stream;
+            }
+            catch
+            {
+                stream?.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Retrieve a new <c>MemoryStream</c> object with the contents copied from the provided
         /// buffer. The provided buffer is not wrapped or used after construction.
         /// </summary>
@@ -904,6 +930,18 @@ namespace Microsoft.IO
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
         public MemoryStream GetStream(Memory<byte> buffer)
+        {
+            return GetStream(null, buffer);
+        }
+
+        /// <summary>
+        /// Retrieve a new <c>MemoryStream</c> object with the contents copied from the provided
+        /// buffer. The provided buffer is not wrapped or used after construction.
+        /// </summary>
+        /// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+        /// <param name="buffer">The byte buffer to copy data from.</param>
+        /// <returns>A <c>MemoryStream</c>.</returns>
+        public MemoryStream GetStream(ReadOnlyMemory<byte> buffer)
         {
             return GetStream(null, buffer);
         }
@@ -917,6 +955,19 @@ namespace Microsoft.IO
         /// <param name="buffer">The byte buffer to copy data from.</param>
         /// <returns>A <c>MemoryStream</c>.</returns>
         public MemoryStream GetStream(string tag, Memory<byte> buffer)
+        {
+            return GetStream(Guid.NewGuid(), tag, buffer);
+        }
+
+        /// <summary>
+        /// Retrieve a new <c>MemoryStream</c> object with the given tag and with contents copied from the provided
+        /// buffer. The provided buffer is not wrapped or used after construction.
+        /// </summary>
+        /// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+        /// <param name="tag">A tag which can be used to track the source of the stream.</param>
+        /// <param name="buffer">The byte buffer to copy data from.</param>
+        /// <returns>A <c>MemoryStream</c>.</returns>
+        public MemoryStream GetStream(string tag, ReadOnlyMemory<byte> buffer)
         {
             return GetStream(Guid.NewGuid(), tag, buffer);
         }


### PR DESCRIPTION
Resolves #199 

This adds `GetStream` overrides that accept `ReadOnlyMemory<byte>`, and a couple of unit tests.

I thought about obsoleting the methods that take `Memory<byte>`, but I think there's no compelling reason to do so since the two types are not actually derived from each other, and I don't want to force a conversion, even implicitly, if not necessary.