### PR TITLE
Add tests to improve code coverage

### DIFF
--- a/UnitTests/RecyclableMemoryStreamEventListener.cs
+++ b/UnitTests/RecyclableMemoryStreamEventListener.cs
@@ -29,6 +29,10 @@ namespace Microsoft.IO.UnitTests
     {
         private const int MemoryStreamDisposed = 2;
         private const int MemoryStreamDoubleDispose = 3;
+        
+        private const int NumEvents = 12;
+
+        public int[] EventCounts { get; } = new int[NumEvents];
 
         public RecyclableMemoryStreamEventListener()
         {
@@ -39,12 +43,13 @@ namespace Microsoft.IO.UnitTests
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            const int TagIndex = 1;
-            this.EventWritten(eventData.EventId, (string)eventData.Payload[TagIndex]);
+            this.EventWritten(eventData.EventId);
         }
 
-        public new virtual void EventWritten(int eventId, string tag)
+        public new virtual void EventWritten(int eventId)
         {
+            this.EventCounts[eventId]++;
+
             switch (eventId)
             {
             case MemoryStreamDisposed:

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -521,7 +521,7 @@ namespace Microsoft.IO.UnitTests
             Assert.That(seg.Array, Is.Empty);
 
             //Non-exception path. Length is too long. No exception.
-            var buffer = GetRandomBuffer(RecyclableMemoryStreamManager.MaxArrayLength);
+            var buffer = new byte[RecyclableMemoryStreamManager.MaxArrayLength];
             stream.Write(buffer);
             stream.Write(buffer);
             Assert.That(stream.TryGetBuffer(out seg), Is.False);
@@ -1391,7 +1391,7 @@ namespace Microsoft.IO.UnitTests
         public void SafeReadByte_Int_ThrowsOnLargeStreamPositionOverflow()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(RecyclableMemoryStreamManager.MaxArrayLength);
+            var buffer = new byte[RecyclableMemoryStreamManager.MaxArrayLength];
             stream.Write(buffer);
             stream.Position = Int32.MaxValue;
             stream.WriteByte(255);
@@ -3376,7 +3376,7 @@ namespace Microsoft.IO.UnitTests
         public void VeryLargeStream_WriteByte()
         {
             var stream = GetMultiGBStream();
-            var buffer = GetRandomBuffer(100 << 20);
+            var buffer = new byte[100 << 20];
             while (stream.Length < DefaultVeryLargeStreamSize)
             {
                 stream.Write(buffer);
@@ -3392,7 +3392,7 @@ namespace Microsoft.IO.UnitTests
         public void VeryLargeStream_GetReadOnlySequence()
         {
             var stream = GetMultiGBStream();
-            var buffer = GetRandomBuffer(100 << 20);
+            var buffer = new byte[100 << 20];
             while (stream.Length < DefaultVeryLargeStreamSize)
             {
                 stream.Write(buffer);

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -230,7 +230,7 @@ namespace Microsoft.IO
         /// <param name="tag">A string identifying this stream for logging and debugging purposes.</param>
         /// <param name="requestedSize">The initial requested size to prevent future allocations.</param>
         public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, Guid id, string tag, int requestedSize)
-            : this(memoryManager, id, tag, requestedSize, null) { }
+            : this(memoryManager, id, tag, (long)requestedSize) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
@@ -404,8 +404,7 @@ namespace Microsoft.IO
             }
             set
             {
-                this.CheckDisposed();
-                this.EnsureCapacity(value);
+                this.Capacity64 = value;
             }
         }
 


### PR DESCRIPTION
Resolves #144 

Brings up code coverage of unit tests to 98%. Remaining lines of code are extremely difficult to cover and are related to rare edge cases in the environment.

~~This increases the runtime of the unit tests by 3x, unfortunately, but I will see if I can get any of that back.~~