### PR TITLE
Fix XML comments for RecyclableMemoryStreamManager.StreamLength

### DIFF
--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.IO
         public event EventHandler<StreamFinalizedEventArgs> StreamFinalized;
 
         /// <summary>
-        /// Triggered when a stream is finalized.
+        /// Triggered when a stream is disposed to report the stream's length.
         /// </summary>
         public event EventHandler<StreamLengthEventArgs> StreamLength;
 


### PR DESCRIPTION
Minor fix to the XML comments of `RecyclableMemoryStreamManager.StreamLength`.