### PR TITLE
Fix ToString to correctly handle disposed streams.

### DIFF
--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -1087,7 +1087,15 @@ namespace Microsoft.IO
         /// </summary>
         public override string ToString()
         {
-            return $"Id = {this.Id}, Tag = {this.Tag}, Length = {this.Length:N0} bytes";
+            if (!this.disposed)
+            {
+                return $"Id = {this.Id}, Tag = {this.Tag}, Length = {this.Length:N0} bytes";
+            }
+            else
+            {
+                // Avoid properties because of the dispose check, but the fields themselves are not cleared.
+                return $"Disposed: Id = {this.id}, Tag = {this.tag}";
+            }
         }
 
         /// <summary>

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -1094,7 +1094,7 @@ namespace Microsoft.IO
             else
             {
                 // Avoid properties because of the dispose check, but the fields themselves are not cleared.
-                return $"Disposed: Id = {this.id}, Tag = {this.tag}";
+                return $"Disposed: Id = {this.id}, Tag = {this.tag}, Final Length: {this.length:N0} bytes";
             }
         }
 


### PR DESCRIPTION
Resolves #242 

Fix `RecyclableMemoryStream.ToString` to show status of disposable, and some still-valid info after the stream is disposed.