### PR TITLE
Update CodeQL to analyze only src directory

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           queries: security-and-quality
 
-      - name: Perform CodeQL Autobuild
-        uses: github/codeql-action/autobuild@v2
+      # - name: Perform CodeQL Autobuild
+      #  uses: github/codeql-action/autobuild@v2
+      
+      - run: |
+         dotnet build /p:UseSharedCompilation=false src
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
The unittests folder has a lot of false failures.