### PR TITLE
Update some events to Warning, add more data

### DIFF
--- a/src/Events.cs
+++ b/src/Events.cs
@@ -229,7 +229,7 @@ namespace Microsoft.IO
             public void MemoryStreamDiscardBuffer(Guid guid, string tag, MemoryStreamBufferType bufferType,
                                                   MemoryStreamDiscardReason reason, long smallBlocksFree, long smallPoolBytesFree, long smallPoolBytesInUse, long largeBlocksFree, long largePoolBytesFree, long largePoolBytesInUse)
             {
-                if (this.IsEnabled())
+                if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
                 {
                     WriteEvent(10, guid, tag ?? string.Empty, bufferType, reason, smallBlocksFree, smallPoolBytesFree, smallPoolBytesInUse, largeBlocksFree, largePoolBytesFree, largePoolBytesInUse);
                 }

--- a/src/Events.cs
+++ b/src/Events.cs
@@ -175,7 +175,7 @@ namespace Microsoft.IO
             [Event(7, Level = EventLevel.Warning, Version = 2)]
             public void MemoryStreamNewBlockCreated(long smallPoolInUseBytes)
             {
-                if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
+                if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
                 {
                     WriteEvent(7, smallPoolInUseBytes);
                 }

--- a/src/Events.cs
+++ b/src/Events.cs
@@ -189,7 +189,7 @@ namespace Microsoft.IO
             [Event(8, Level = EventLevel.Warning, Version = 3)]
             public void MemoryStreamNewLargeBufferCreated(long requiredSize, long largePoolInUseBytes)
             {
-                if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
+                if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
                 {
                     WriteEvent(8, requiredSize, largePoolInUseBytes);
                 }

--- a/src/Events.cs
+++ b/src/Events.cs
@@ -172,7 +172,7 @@ namespace Microsoft.IO
             /// Logged when a new block is created.
             /// </summary>
             /// <param name="smallPoolInUseBytes">Number of bytes in the small pool currently in use.</param>
-            [Event(7, Level = EventLevel.Verbose)]
+            [Event(7, Level = EventLevel.Warning, Version = 2)]
             public void MemoryStreamNewBlockCreated(long smallPoolInUseBytes)
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
@@ -186,7 +186,7 @@ namespace Microsoft.IO
             /// </summary>
             /// <param name="requiredSize">Requested size.</param>
             /// <param name="largePoolInUseBytes">Number of bytes in the large pool in use.</param>
-            [Event(8, Level = EventLevel.Verbose, Version = 2)]
+            [Event(8, Level = EventLevel.Warning, Version = 3)]
             public void MemoryStreamNewLargeBufferCreated(long requiredSize, long largePoolInUseBytes)
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
@@ -219,13 +219,19 @@ namespace Microsoft.IO
             /// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
             /// <param name="bufferType">Type of the buffer being discarded.</param>
             /// <param name="reason">Reason for the discard.</param>
+            /// <param name="smallBlocksFree">Number of free small pool blocks.</param>
+            /// <param name="smallPoolBytesFree">Bytes free in the small pool.</param>
+            /// <param name="smallPoolBytesInUse">Bytes in use from the small pool.</param>
+            /// <param name="largeBlocksFree">Number of free large pool blocks.</param>
+            /// <param name="largePoolBytesFree">Bytes free in the large pool.</param>
+            /// <param name="largePoolBytesInUse">Bytes in use from the large pool.</param>
             [Event(10, Level = EventLevel.Warning, Version = 2)]
             public void MemoryStreamDiscardBuffer(Guid guid, string tag, MemoryStreamBufferType bufferType,
-                                                  MemoryStreamDiscardReason reason)
+                                                  MemoryStreamDiscardReason reason, long smallBlocksFree, long smallPoolBytesFree, long smallPoolBytesInUse, long largeBlocksFree, long largePoolBytesFree, long largePoolBytesInUse)
             {
                 if (this.IsEnabled())
                 {
-                    WriteEvent(10, guid, tag ?? string.Empty, bufferType, reason);
+                    WriteEvent(10, guid, tag ?? string.Empty, bufferType, reason, smallBlocksFree, smallPoolBytesFree, smallPoolBytesInUse, largeBlocksFree, largePoolBytesFree, largePoolBytesInUse);
                 }
             }
 

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -662,7 +662,9 @@ namespace Microsoft.IO
 
         internal void ReportBufferDiscarded(Guid id, string tag, Events.MemoryStreamBufferType bufferType, Events.MemoryStreamDiscardReason reason)
         {
-            Events.Writer.MemoryStreamDiscardBuffer(id, tag, bufferType, reason);
+            Events.Writer.MemoryStreamDiscardBuffer(id, tag, bufferType, reason,
+                this.SmallBlocksFree, this.smallPoolFreeSize, this.smallPoolInUseSize,
+                this.LargeBuffersFree, this.LargePoolFreeSize, this.LargePoolInUseSize);
             this.BufferDiscarded?.Invoke(this, new BufferDiscardedEventArgs(id, tag, bufferType, reason));
         }
 


### PR DESCRIPTION
I was recently debugging a metrics issue stemming from RecyclableMemoryStream and at one point I wished I had a bit more data in some of these events. There are two changes:

|Change|Justification|
|-----|------|
|Change Block/Buffer creation events to Warning from Verbose|After the pool is "warmed" up, these should be rare occurrences, and indicate that the configured slack space is insufficient. Downside is that when the pool is warming up, there will be more. However, if you're debugging at a later point, it's much easier to see these events without the sea of verbose events.|
|Add pool info to Discard event|On the flip side, if a buffer/block is discarded, the pool is larger than anticipated. It would be useful to see exactly the state.|