### PR TITLE
Change when pool stats are reported

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -3665,8 +3665,8 @@ namespace Microsoft.IO.UnitTests
             long requestedSize = mgr.BlockSize;
             mgr.UsageReport += (obj, args) =>
             {
-                Assert.That(args.SmallPoolFreeBytes, Is.EqualTo(mgr.BlockSize));
-                Assert.That(args.SmallPoolInUseBytes, Is.EqualTo(0));
+                Assert.That(args.SmallPoolFreeBytes, Is.EqualTo(raisedCount == 0 ? 0 : mgr.BlockSize));
+                Assert.That(args.SmallPoolInUseBytes, Is.EqualTo(raisedCount == 0 ? mgr.BlockSize : 0));
                 Assert.That(args.LargePoolFreeBytes, Is.EqualTo(0));
                 Assert.That(args.LargePoolInUseBytes, Is.EqualTo(0));
 
@@ -3679,7 +3679,7 @@ namespace Microsoft.IO.UnitTests
             stream.GetBuffer();
             stream.Dispose();
 
-            Assert.That(raisedCount, Is.EqualTo(1));
+            Assert.That(raisedCount, Is.EqualTo(2));
         }
 
         #endregion

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -274,6 +274,7 @@ namespace Microsoft.IO
             }
 
             this.memoryManager.ReportStreamCreated(this.id, this.tag, requestedSize, actualRequestedSize);
+            this.memoryManager.ReportUsageReport();
         }
         #endregion
 
@@ -349,6 +350,7 @@ namespace Microsoft.IO
             }
 
             this.memoryManager.ReturnBlocks(this.blocks, this.id, this.tag);
+            this.memoryManager.ReportUsageReport();
             this.blocks.Clear();
 
             base.Dispose(disposing);

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -555,9 +555,6 @@ namespace Microsoft.IO
             }
 
             Interlocked.Add(ref this.largeBufferInUseSize[poolIndex], -buffer.Length);
-
-            ReportUsageReport(this.smallPoolInUseSize, this.smallPoolFreeSize, this.LargePoolInUseSize,
-                              this.LargePoolFreeSize);
         }
 
         /// <summary>
@@ -599,9 +596,6 @@ namespace Microsoft.IO
                     break;
                 }
             }
-
-            ReportUsageReport(this.smallPoolInUseSize, this.smallPoolFreeSize, this.LargePoolInUseSize,
-                              this.LargePoolFreeSize);
         }
 
         /// <summary>
@@ -636,9 +630,6 @@ namespace Microsoft.IO
             {
                 ReportBufferDiscarded(id, tag, Events.MemoryStreamBufferType.Small, Events.MemoryStreamDiscardReason.EnoughFree);
             }
-
-            ReportUsageReport(this.smallPoolInUseSize, this.smallPoolFreeSize, this.LargePoolInUseSize,
-                              this.LargePoolFreeSize);
         }
 
         internal void ReportBlockCreated()
@@ -707,9 +698,9 @@ namespace Microsoft.IO
             this.StreamOverCapacity?.Invoke(this, new StreamOverCapacityEventArgs(id, tag, requestedCapacity, this.MaximumStreamCapacity, allocationStack));
         }
 
-        internal void ReportUsageReport(long smallPoolInUseBytes, long smallPoolFreeBytes, long largePoolInUseBytes, long largePoolFreeBytes)
+        internal void ReportUsageReport()
         {
-            this.UsageReport?.Invoke(this, new UsageReportEventArgs(smallPoolInUseBytes, smallPoolFreeBytes, largePoolInUseBytes, largePoolFreeBytes));
+            this.UsageReport?.Invoke(this, new UsageReportEventArgs(this.smallPoolInUseSize, this.smallPoolFreeSize, this.LargePoolInUseSize, this.LargePoolFreeSize));
         }
 
         /// <summary>


### PR DESCRIPTION
Pool stats are currently only reported when blocks/buffers are returned. If you have a ton of long-lived streams being created, this can lead to a very skewed set of statistics. It would be fairer to also update stats when blocks/buffers are retrieved, but this might double the times the API is called.

Instead, I moved the reporting to stream creation and disposal. This should balance things out.

I also changed the method signature to be empty because it was using member variables all the time anyway.