### PR TITLE
Add tracking for stream lifetime

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.IO.UnitTests
     using System;
     using System.Buffers;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Runtime.InteropServices;
     using System.Threading;
@@ -3447,7 +3448,7 @@ namespace Microsoft.IO.UnitTests
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
                 Assert.That(args.Tag, Is.EqualTo("UnitTest"));
-                Assert.That(args.Lifetime, Is.GreaterThan(TimeSpan.Zero));
+                Assert.That(args.Lifetime, Is.GreaterThan(TimeSpan.Zero), $"TicksPerSecond: {TimeSpan.TicksPerSecond}, Freq: {Stopwatch.Frequency} Div:{TimeSpan.TicksPerSecond / Stopwatch.Frequency}");
                 Assert.That(args.Lifetime, Is.LessThan(TimeSpan.FromSeconds(2)));
                 Assert.That(args.AllocationStack, Contains.Substring("Microsoft.IO.RecyclableMemoryStream..ctor"));
                 Assert.That(args.DisposeStack, Contains.Substring("Microsoft.IO.RecyclableMemoryStream.Dispose"));

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2660,11 +2660,11 @@ namespace Microsoft.IO.UnitTests
 
             mgr.StreamDisposed += (obj, args) =>
             {
-                Assert.That(args.Lifetime, Is.GreaterThan(TimeSpan.Zero));
+                Assert.That(args.Lifetime, Is.GreaterThanOrEqualTo(TimeSpan.Zero));
             };
 
             CreateDeadStream(mgr, expectedGuid, "Tag");
-            Thread.Sleep(10);
+            Thread.Sleep(100);
 
             GC.Collect(2, GCCollectionMode.Forced, true);
             GC.WaitForPendingFinalizers();
@@ -3454,7 +3454,7 @@ namespace Microsoft.IO.UnitTests
                 raised = true;
             };
             var stream = mgr.GetStream("UnitTest", 13);
-            Thread.Sleep(10);
+            Thread.Sleep(100);
             stream.Dispose();
             Assert.That(raised, Is.True);
         }

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2661,7 +2661,6 @@ namespace Microsoft.IO.UnitTests
             mgr.StreamDisposed += (obj, args) =>
             {
                 Assert.That(args.Lifetime, Is.GreaterThan(TimeSpan.Zero));
-                Assert.That(args.Lifetime, Is.LessThan(TimeSpan.FromSeconds(5)));
             };
 
             CreateDeadStream(mgr, expectedGuid, "Tag");

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2658,6 +2658,12 @@ namespace Microsoft.IO.UnitTests
                 handlerTriggered = true;
             };
 
+            mgr.StreamDisposed += (obj, args) =>
+            {
+                Assert.That(args.Lifetime, Is.GreaterThan(TimeSpan.Zero));
+                Assert.That(args.Lifetime, Is.LessThan(TimeSpan.FromSeconds(5)));
+            };
+
             CreateDeadStream(mgr, expectedGuid, "Tag");
 
             GC.Collect(2, GCCollectionMode.Forced, true);
@@ -3441,6 +3447,8 @@ namespace Microsoft.IO.UnitTests
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
                 Assert.That(args.Tag, Is.EqualTo("UnitTest"));
+                Assert.That(args.Lifetime, Is.GreaterThan(TimeSpan.Zero));
+                Assert.That(args.Lifetime, Is.LessThan(TimeSpan.FromSeconds(2)));
                 Assert.That(args.AllocationStack, Contains.Substring("Microsoft.IO.RecyclableMemoryStream..ctor"));
                 Assert.That(args.DisposeStack, Contains.Substring("Microsoft.IO.RecyclableMemoryStream.Dispose"));
                 raised = true;

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -2664,6 +2664,7 @@ namespace Microsoft.IO.UnitTests
             };
 
             CreateDeadStream(mgr, expectedGuid, "Tag");
+            Thread.Sleep(10);
 
             GC.Collect(2, GCCollectionMode.Forced, true);
             GC.WaitForPendingFinalizers();
@@ -3453,6 +3454,7 @@ namespace Microsoft.IO.UnitTests
                 raised = true;
             };
             var stream = mgr.GetStream("UnitTest", 13);
+            Thread.Sleep(10);
             stream.Dispose();
             Assert.That(raised, Is.True);
         }

--- a/src/EventArgs.cs
+++ b/src/EventArgs.cs
@@ -71,16 +71,23 @@
             public string DisposeStack { get; }
 
             /// <summary>
+            /// Lifetime of the stream
+            /// </summary>
+            public TimeSpan Lifetime { get; }
+
+            /// <summary>
             /// Initializes a new instance of the <see cref="StreamDisposedEventArgs"/> class.
             /// </summary>
             /// <param name="guid">Unique ID of the stream.</param>
             /// <param name="tag">Tag of the stream.</param>
+            /// <param name="lifetime">Lifetime of the stream</param>
             /// <param name="allocationStack">Stack of original allocation.</param>
             /// <param name="disposeStack">Dispose stack.</param>
-            public StreamDisposedEventArgs(Guid guid, string tag, string allocationStack, string disposeStack)
+            public StreamDisposedEventArgs(Guid guid, string tag, TimeSpan lifetime, string allocationStack, string disposeStack)
             {
                 this.Id = guid;
                 this.Tag = tag;
+                this.Lifetime= lifetime;
                 this.AllocationStack = allocationStack;
                 this.DisposeStack = disposeStack;
             }

--- a/src/EventArgs.cs
+++ b/src/EventArgs.cs
@@ -80,6 +80,20 @@
             /// </summary>
             /// <param name="guid">Unique ID of the stream.</param>
             /// <param name="tag">Tag of the stream.</param>
+            /// <param name="allocationStack">Stack of original allocation.</param>
+            /// <param name="disposeStack">Dispose stack.</param>
+            [Obsolete("Use another constructor override")]
+            public StreamDisposedEventArgs(Guid guid, string tag, string allocationStack, string disposeStack)
+                :this(guid, tag, TimeSpan.Zero, allocationStack, disposeStack)
+            {
+                
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="StreamDisposedEventArgs"/> class.
+            /// </summary>
+            /// <param name="guid">Unique ID of the stream.</param>
+            /// <param name="tag">Tag of the stream.</param>
             /// <param name="lifetime">Lifetime of the stream</param>
             /// <param name="allocationStack">Stack of original allocation.</param>
             /// <param name="disposeStack">Dispose stack.</param>
@@ -87,7 +101,7 @@
             {
                 this.Id = guid;
                 this.Tag = tag;
-                this.Lifetime= lifetime;
+                this.Lifetime = lifetime;
                 this.AllocationStack = allocationStack;
                 this.DisposeStack = disposeStack;
             }

--- a/src/Events.cs
+++ b/src/Events.cs
@@ -89,14 +89,15 @@ namespace Microsoft.IO
             /// </summary>
             /// <param name="guid">A unique ID for this stream.</param>
             /// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+            /// <param name="lifetime">Lifetime of the stream</param>
             /// <param name="allocationStack">Call stack of initial allocation.</param>
             /// <param name="disposeStack">Call stack of the dispose.</param>
-            [Event(2, Level = EventLevel.Verbose, Version = 2)]
-            public void MemoryStreamDisposed(Guid guid, string tag, string allocationStack, string disposeStack)
+            [Event(2, Level = EventLevel.Verbose, Version = 3)]
+            public void MemoryStreamDisposed(Guid guid, string tag, TimeSpan lifetime, string allocationStack, string disposeStack)
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
                 {
-                    WriteEvent(2, guid, tag ?? string.Empty, allocationStack ?? string.Empty, disposeStack ?? string.Empty);
+                    WriteEvent(2, guid, tag ?? string.Empty, lifetime, allocationStack ?? string.Empty, disposeStack ?? string.Empty);
                 }
             }
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -311,7 +311,7 @@ namespace Microsoft.IO
             }
 
             this.disposed = true;
-            var lifetime = TimeSpan.FromTicks(Stopwatch.GetTimestamp() - this.creationTimestamp);
+            var lifetime = TimeSpan.FromTicks((long)((Stopwatch.GetTimestamp() - this.creationTimestamp) * (TimeSpan.TicksPerSecond / Stopwatch.Frequency)));
 
             if (this.memoryManager.GenerateCallStacks)
             {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -311,7 +311,7 @@ namespace Microsoft.IO
             }
 
             this.disposed = true;
-            var lifetime = TimeSpan.FromTicks((Stopwatch.GetTimestamp() - this.creationTimestamp) * (TimeSpan.TicksPerSecond / Stopwatch.Frequency));
+            var lifetime = TimeSpan.FromTicks((long)((Stopwatch.GetTimestamp() - this.creationTimestamp) * ((double)TimeSpan.TicksPerSecond / Stopwatch.Frequency)));
 
             if (this.memoryManager.GenerateCallStacks)
             {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -311,7 +311,7 @@ namespace Microsoft.IO
             }
 
             this.disposed = true;
-            var lifetime = TimeSpan.FromTicks((long)((Stopwatch.GetTimestamp() - this.creationTimestamp) * (TimeSpan.TicksPerSecond / Stopwatch.Frequency)));
+            var lifetime = TimeSpan.FromTicks((Stopwatch.GetTimestamp() - this.creationTimestamp) * (TimeSpan.TicksPerSecond / Stopwatch.Frequency));
 
             if (this.memoryManager.GenerateCallStacks)
             {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -102,6 +102,8 @@ namespace Microsoft.IO
 
         private readonly string tag;
 
+        private long creationTimestamp;
+
         /// <summary>
         /// This list is used to store buffers once they're replaced by something larger.
         /// This is for the cases where you have users of this class that may hold onto the buffers longer
@@ -257,6 +259,7 @@ namespace Microsoft.IO
             this.id = id;
             this.tag = tag;
             this.blocks = new List<byte[]>();
+            this.creationTimestamp = Stopwatch.GetTimestamp();
 
             var actualRequestedSize = Math.Max(requestedSize, this.memoryManager.BlockSize);
 
@@ -308,13 +311,14 @@ namespace Microsoft.IO
             }
 
             this.disposed = true;
+            var lifetime = TimeSpan.FromTicks(Stopwatch.GetTimestamp() - this.creationTimestamp);
 
             if (this.memoryManager.GenerateCallStacks)
             {
                 this.DisposeStack = Environment.StackTrace;
             }
 
-            this.memoryManager.ReportStreamDisposed(this.id, this.tag, this.AllocationStack, this.DisposeStack);
+            this.memoryManager.ReportStreamDisposed(this.id, this.tag, lifetime, this.AllocationStack, this.DisposeStack);
 
             if (disposing)
             {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -311,7 +311,7 @@ namespace Microsoft.IO
             }
 
             this.disposed = true;
-            var lifetime = TimeSpan.FromTicks((long)((Stopwatch.GetTimestamp() - this.creationTimestamp) * ((double)TimeSpan.TicksPerSecond / Stopwatch.Frequency)));
+            var lifetime = TimeSpan.FromTicks((Stopwatch.GetTimestamp() - this.creationTimestamp) * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
 
             if (this.memoryManager.GenerateCallStacks)
             {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -102,7 +102,7 @@ namespace Microsoft.IO
 
         private readonly string tag;
 
-        private long creationTimestamp;
+        private readonly long creationTimestamp;
 
         /// <summary>
         /// This list is used to store buffers once they're replaced by something larger.

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -665,10 +665,10 @@ namespace Microsoft.IO
             this.StreamCreated?.Invoke(this, new StreamCreatedEventArgs(id, tag, requestedSize, actualSize));
         }
 
-        internal void ReportStreamDisposed(Guid id, string tag, string allocationStack, string disposeStack)
+        internal void ReportStreamDisposed(Guid id, string tag, TimeSpan lifetime, string allocationStack, string disposeStack)
         {
-            Events.Writer.MemoryStreamDisposed(id, tag, allocationStack, disposeStack);
-            this.StreamDisposed?.Invoke(this, new StreamDisposedEventArgs(id, tag, allocationStack, disposeStack));
+            Events.Writer.MemoryStreamDisposed(id, tag, lifetime, allocationStack, disposeStack);
+            this.StreamDisposed?.Invoke(this, new StreamDisposedEventArgs(id, tag, lifetime, allocationStack, disposeStack));
         }
 
         internal void ReportStreamDoubleDisposed(Guid id, string tag, string allocationStack, string disposeStack1, string disposeStack2)


### PR DESCRIPTION
An insufficiently managed pool is indistinguishable from a memory leak. One area that would be nice to have is the ability to track the length of time streams are active. This would inform pool configuration, especially as it changes over time.

In our own service, I would hook this up to a performance counter to track over time.

I've also put the lifetime value in the Dispose ETW event, which is a verbose event.