### PR TITLE
More optimized remainder calculation

### DIFF
--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -1120,14 +1120,14 @@ namespace Microsoft.IO
             {
                 var blockSize = this.memoryManager.BlockSize;
 
-                var block = (int)(this.position / blockSize);
+                var block = (int)Math.DivRem(this.position, blockSize, out var index);
 
                 if (block >= this.blocks.Count)
                 {
                     this.EnsureCapacity(end);
                 }
 
-                this.blocks[block][this.position % blockSize] = value;
+                this.blocks[block][index] = value;
             }
             else
             {
@@ -1528,9 +1528,8 @@ namespace Microsoft.IO
         private BlockAndOffset GetBlockAndRelativeOffset(long offset)
         {
             var blockSize = this.memoryManager.BlockSize;
-            int blockIndex = (int)(offset / blockSize);
-            int offsetIndex = (int)(offset % blockSize);
-            return new BlockAndOffset(blockIndex, offsetIndex);
+            int blockIndex = (int)Math.DivRem(offset, blockSize, out long offsetIndex);
+            return new BlockAndOffset(blockIndex, (int)offsetIndex);
         }
 
         private void EnsureCapacity(long newCapacity)


### PR DESCRIPTION
Instead of division then remainder operation, used Math.DivRem which handles it in a more optimized way. It uses only a single division, multiplication, and subtraction instead of two divisions. Moreover, in the future, it can be even more optimized using intrinsics.

See:
https://github.com/dotnet/runtime/issues/5213#issuecomment-260448104