### PR TITLE
Throw ArgumentNullException instead of NullReferenceException in RecyclableMemoryStream ctor

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -803,6 +803,16 @@ namespace Microsoft.IO.UnitTests
 
         #region Constructor tests
         [Test]
+        public void NullMemoryManagerThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new RecyclableMemoryStream(null));
+            Assert.Throws<ArgumentNullException>(() => new RecyclableMemoryStream(null, Guid.NewGuid()));
+            Assert.Throws<ArgumentNullException>(() => new RecyclableMemoryStream(null, Guid.NewGuid(), "tag"));
+            Assert.Throws<ArgumentNullException>(() => new RecyclableMemoryStream(null, Guid.NewGuid(), "tag", 100));
+            Assert.Throws<ArgumentNullException>(() => new RecyclableMemoryStream(null, Guid.NewGuid(), "tag", 100, new byte[0]));
+        }
+
+        [Test]
         public void StreamHasGuid()
         {
             var expectedGuid = Guid.NewGuid();

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -255,6 +255,11 @@ namespace Microsoft.IO
         internal RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, Guid id, string tag, long requestedSize, byte[] initialLargeBuffer)
             : base(emptyArray)
         {
+            if (memoryManager == null)
+            {
+                throw new ArgumentNullException(nameof(memoryManager));
+            }
+
             this.memoryManager = memoryManager;
             this.id = id;
             this.tag = tag;


### PR DESCRIPTION
 ArgumentNullException is better because says which parameter was null. Throwing NullReferenceException in libraries is a bad practice.