### PR TITLE
Override CopyTo to improve performance

### DIFF
--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -555,7 +555,7 @@ namespace Microsoft.IO
         /// <inheritdoc/>
         public override void CopyTo(Stream destination, int bufferSize)
         {
-            CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();
+            WriteTo(destination, this.position, this.length - this.position);
         }
 #endif
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -551,6 +551,14 @@ namespace Microsoft.IO
             return this.largeBuffer;
         }
 
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+        /// <inheritdoc/>
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            CopyToAsync(destination, bufferSize, CancellationToken.None).GetAwaiter().GetResult();
+        }
+#endif
+
         /// <summary>Asynchronously reads all the bytes from the current position in this stream and writes them to another stream.</summary>
         /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
         /// <param name="bufferSize">This parameter is ignored.</param>


### PR DESCRIPTION
If CopyTo is not overridden, it is used the default implementation in Stream class which is inefficient as it uses ArrayPool and writes in loop.