### PR TITLE
Add continuous benchmarking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,35 @@
+name: Benchmark Tests
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run Benchmark.Net
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.x'
+      - name: Run benchmark
+        run: cd BenchmarkTests && dotnet run -c Release --framework net7.0 --exporters json --filter '*'
+
+      - name: Combine benchmark results
+        run: dotnet tool install -g dotnet-script && cd BenchmarkTests && dotnet script combine-bechmarks.csx
+
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: Benchmark.Net Benchmark
+          tool: 'benchmarkdotnet'
+          output-file-path: BenchmarkTests/BenchmarkDotNet.Artifacts/results/Combined.Benchmarks.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '200%'
+          comment-on-alert: true

--- a/BenchmarkTests/BenchmarkTests.csproj
+++ b/BenchmarkTests/BenchmarkTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.IO.RecyclableMemoryStream.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BenchmarkTests/Program.cs
+++ b/BenchmarkTests/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Running;
+
+var config = ManualConfig
+  .Create(DefaultConfig.Instance)
+  .AddDiagnoser(MemoryDiagnoser.Default);
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);

--- a/BenchmarkTests/WriteTests.cs
+++ b/BenchmarkTests/WriteTests.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.IO;
+
+namespace BenchmarkTests;
+
+public class WriteTest
+{
+    private RecyclableMemoryStream? subject;
+    private readonly byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        var manager = new RecyclableMemoryStreamManager();
+        this.subject = new RecyclableMemoryStream(manager);
+    }
+
+    [Benchmark]
+    public void WriteByte()
+    {
+        for (int i = 0; i < 10_000_000; i++)
+        {
+            this.subject!.WriteByte(1);
+        }
+    }
+
+    [Benchmark]
+    public void WriteSpan()
+    {
+        for (int i = 0; i < 10_000_000; i++)
+        {
+            this.subject!.Write(bytes.AsSpan());
+        }
+    }
+}

--- a/BenchmarkTests/combine-bechmarks.csx
+++ b/BenchmarkTests/combine-bechmarks.csx
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+string resultsDir = "./BenchmarkDotNet.Artifacts/results";
+string resultsFile = "Combined.Benchmarks";
+string searchPattern = "*-report-full-compressed.json";
+
+var resultsPath = Path.Combine(resultsDir, resultsFile + ".json");
+
+if (!Directory.Exists(resultsDir))
+{
+	throw new DirectoryNotFoundException($"Directory not found '{resultsDir}'");
+}
+
+if (File.Exists(resultsPath))
+{
+	File.Delete(resultsPath);
+}
+
+var reports = Directory
+	.GetFiles(resultsDir, searchPattern, SearchOption.TopDirectoryOnly)
+	.ToArray();
+if (!reports.Any())
+{
+	throw new FileNotFoundException($"Reports not found '{searchPattern}'");
+}
+
+var combinedReport = JsonNode.Parse(File.ReadAllText(reports.First()))!;
+var title = combinedReport["Title"]!;
+var benchmarks = combinedReport["Benchmarks"]!.AsArray();
+// Rename title whilst keeping original timestamp
+combinedReport["Title"] = $"{resultsFile}{title.GetValue<string>()[^16..]}";
+
+foreach (var report in reports.Skip(1))
+{
+	var array = JsonNode.Parse(File.ReadAllText(report))!["Benchmarks"]!.AsArray();
+	foreach (var benchmark in array)
+	{
+		// Double parse avoids "The node already has a parent" exception
+		benchmarks.Add(JsonNode.Parse(benchmark!.ToJsonString())!);
+	}
+}
+
+File.WriteAllText(resultsPath, combinedReport.ToString());

--- a/Microsoft.IO.RecyclableMemoryStream.sln
+++ b/Microsoft.IO.RecyclableMemoryStream.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkTests", "BenchmarkTests\BenchmarkTests.csproj", "{731CCC6D-2583-4CB0-A439-8173E9722E4D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{419C9F3D-71CC-4F95-8324-E15CD0D1E754}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{419C9F3D-71CC-4F95-8324-E15CD0D1E754}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{419C9F3D-71CC-4F95-8324-E15CD0D1E754}.Release|Any CPU.Build.0 = Release|Any CPU
+		{731CCC6D-2583-4CB0-A439-8173E9722E4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{731CCC6D-2583-4CB0-A439-8173E9722E4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{731CCC6D-2583-4CB0-A439-8173E9722E4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{731CCC6D-2583-4CB0-A439-8173E9722E4D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
resolves #277 

What is needed to configure:
- create remote branch gh-pages
- in `Settings -> Pages -> Build and deployment` select branch gh-pages
- the page with benchmark results will be accessible in https://microsoft.github.io/Microsoft.IO.RecyclableMemoryStream/dev/bench/ 