### PR TITLE
Update RMS to version 3.0.0, remove obsolete .NET targets, update package dependency versions

### DIFF
--- a/BenchmarkTests/BenchmarkTests.csproj
+++ b/BenchmarkTests/BenchmarkTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -6,9 +6,9 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.IO.RecyclableMemoryStream.csproj" />

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.IO</RootNamespace>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.IO.RecyclableMemoryStream.xml</DocumentationFile>
     <!-- NuGet properties -->
     <PackageId>Microsoft.IO.RecyclableMemoryStream</PackageId>
-    <PackageVersion>2.3.2</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <Title>Microsoft.IO.RecyclableMemoryStream</Title>
     <Authors>Microsoft</Authors>
     <Description>A pooled MemoryStream allocator to decrease GC load and improve performance on highly scalable systems.</Description>
@@ -50,7 +50,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,6 +59,6 @@
 
   <!-- Workaround for https://github.com/dotnet/sdk/issues/11105 -->
   <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)" Condition="'$(NuGetPackageRoot)' != ''" />
+    <SourceRoot Include="$(NuGetPackageRoot)\" Condition="'$(NuGetPackageRoot)' != ''" />
   </ItemGroup>
 </Project>

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.2.0")]
-[assembly: AssemblyFileVersion("2.3.2.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 //
 // Copyright (c) 2015-2016 Microsoft
 //
@@ -530,7 +530,7 @@ namespace Microsoft.IO
             return this.largeBuffer;
         }
 
-#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         /// <inheritdoc/>
         public override void CopyTo(Stream destination, int bufferSize)
         {
@@ -790,7 +790,7 @@ namespace Microsoft.IO
             {
             }
 
-#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             buffer = ArraySegment<byte>.Empty;
 #else
             buffer = new ArraySegment<byte>();
@@ -891,7 +891,7 @@ namespace Microsoft.IO
         /// <param name="buffer">Destination buffer.</param>
         /// <returns>The number of bytes read.</returns>
         /// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
-#if NETSTANDARD2_0 || NET462
+#if NETSTANDARD2_0
         public int Read(Span<byte> buffer)
 #else
         public override int Read(Span<byte> buffer)
@@ -991,7 +991,7 @@ namespace Microsoft.IO
         /// <param name="source">Source buffer.</param>
         /// <exception cref="ArgumentNullException">buffer is null.</exception>
         /// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
-#if NETSTANDARD2_0 || NET462
+#if NETSTANDARD2_0
         public void Write(ReadOnlySpan<byte> source)
 #else
         public override void Write(ReadOnlySpan<byte> source)

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -386,7 +386,7 @@ namespace Microsoft.IO
             {
                 // We'll add this back to the pool when the stream is disposed
                 // (unless our free pool is too large)
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
                 block = this.ZeroOutBuffer ? GC.AllocateArray<byte>(BlockSize) : GC.AllocateUninitializedArray<byte>(this.BlockSize);
 #else
                 block = new byte[this.BlockSize];
@@ -467,7 +467,7 @@ namespace Microsoft.IO
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static byte[] AllocateArray(long requiredSize, bool zeroInitializeArray) =>
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
                 zeroInitializeArray ? GC.AllocateArray<byte>((int)requiredSize) : GC.AllocateUninitializedArray<byte>((int)requiredSize);
 #else
                 new byte[requiredSize];


### PR DESCRIPTION
Three main changes in this PR:

1. Update all NuGet dependencies to their latest versions.
2. Remove net462, netcoreapp2.1, and net5.0 targets; Add net6.0. Update related code.
3. Update project version to 3.0.0