### PR TITLE
Introduce an Options class for managing RMSManager settings

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------
+// ---------------------------------------------------------------------
 // Copyright (c) 2015 Microsoft
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -65,70 +65,76 @@ namespace Microsoft.IO.UnitTests
 
         #region RecyclableMemoryManager Tests
         [Test]
+        public void OptionsAndSettingsTheSame()
+        {
+            var memMgr = this.GetMemoryManager();
+            memMgr.options.BlockSize = 13;
+            Assert.That(memMgr.Settings.BlockSize, Is.EqualTo(13));
+        }
+
+        [Test]
         public virtual void RecyclableMemoryManagerUsingMultipleOrExponentialLargeBuffer()
         {
             var memMgr = this.GetMemoryManager();
-            Assert.That(memMgr.UseMultipleLargeBuffer, Is.True);
-            Assert.That(memMgr.UseExponentialLargeBuffer, Is.False);
+            Assert.That(memMgr.options.UseExponentialLargeBuffer, Is.False);
         }
 
         [Test]
         public void RecyclableMemoryManagerSetsMaxPoolFreeBytes()
         {
-            var memMgr = new RecyclableMemoryStreamManager(1000, 2000);
-            Assert.That(memMgr.MaximumFreeSmallPoolBytes, Is.EqualTo(1000));
-            Assert.That(memMgr.MaximumFreeLargePoolBytes, Is.EqualTo(2000));
-            Assert.That(memMgr.BlockSize, Is.EqualTo(RecyclableMemoryStreamManager.DefaultBlockSize));
+            var memMgr = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options(DefaultBlockSize, DefaultLargeBufferMultiple, DefaultMaximumBufferSize, DefaultBlockSize * 2, DefaultLargeBufferMultiple * 4));
+            Assert.That(memMgr.options.MaximumSmallPoolFreeBytes, Is.EqualTo(DefaultBlockSize * 2));
+            Assert.That(memMgr.options.MaximumLargePoolFreeBytes, Is.EqualTo(DefaultLargeBufferMultiple * 4));
+            Assert.That(memMgr.options.BlockSize, Is.EqualTo(DefaultBlockSize));
         }
 
         [Test]
         public void RecyclableMemoryManagerSetsBlockSizeLargeBufferMultipleAndMaximumBufferSize()
         {
-            var memMgr = new RecyclableMemoryStreamManager(10, 1000, 8000);
-            Assert.That(memMgr.BlockSize, Is.EqualTo(10));
-            Assert.That(memMgr.LargeBufferMultiple, Is.EqualTo(1000));
-            Assert.That(memMgr.MaximumBufferSize, Is.EqualTo(8000));
+            var memMgr = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 10, LargeBufferMultiple = 1000, MaximumBufferSize = 8000 });
+            Assert.That(memMgr.options.BlockSize, Is.EqualTo(10));
+            Assert.That(memMgr.options.LargeBufferMultiple, Is.EqualTo(1000));
+            Assert.That(memMgr.options.MaximumBufferSize, Is.EqualTo(8000));
         }
 
         [Test]
         public void RecyclableMemoryManagerThrowsExceptionOnZeroBlockSize()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(0, 100, 200, this.UseExponentialLargeBuffer));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(-1, 100, 200, this.UseExponentialLargeBuffer));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(1, 100, 200, this.UseExponentialLargeBuffer));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 0, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = -1, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 1, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
         }
 
         [Test]
         public void RecyclableMemoryManagerThrowsExceptionOnZeroLargeBufferMultipleSize()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(100, 0, 200, this.UseExponentialLargeBuffer));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(100, -1, 200, this.UseExponentialLargeBuffer));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(100, 100, 200, this.UseExponentialLargeBuffer));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 0, MaximumBufferSize = 200, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = -1, MaximumBufferSize = 200, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
         }
 
         [Test]
         public void RecyclableMemoryManagerThrowsExceptionOnMaximumBufferSizeLessThanBlockSize()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(100, 100, 99, this.UseExponentialLargeBuffer));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(100, 100, 100, this.UseExponentialLargeBuffer));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 100, MaximumBufferSize = 99, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 100, MaximumBufferSize = 100, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
         }
 
         [Test]
         public virtual void RecyclableMemoryManagerThrowsExceptionOnMaximumBufferNotMultipleOrExponentialOfLargeBufferMultiple()
         {
-            Assert.Throws<ArgumentException>(() => new RecyclableMemoryStreamManager(100, 1024, 2025, this.UseExponentialLargeBuffer));
-            Assert.Throws<ArgumentException>(() => new RecyclableMemoryStreamManager(100, 1024, 2023, this.UseExponentialLargeBuffer));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(100, 1024, 2048, this.UseExponentialLargeBuffer));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 2025, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 2023, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 2048, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
         }
 
         [Test]
         public void RecyclableMemoryManagerThrowsExceptionOnNegativeMaxFreeSizes()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(1, 100, 200, false, -1, 1000));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new RecyclableMemoryStreamManager(1, 100, 200, false, 1000, -1));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(1, 100, 200, false, 1000, 1000));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(1, 100, 200, false, 0, 0));
-
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 1, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = false, MaximumSmallPoolFreeBytes = -1, MaximumLargePoolFreeBytes = 1000 }));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 1, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = false, MaximumSmallPoolFreeBytes = 1000, MaximumLargePoolFreeBytes = -1 }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 1, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = false, MaximumSmallPoolFreeBytes = 1000, MaximumLargePoolFreeBytes = 1000 }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 1, LargeBufferMultiple = 100, MaximumBufferSize = 200, UseExponentialLargeBuffer = false, MaximumSmallPoolFreeBytes = 0, MaximumLargePoolFreeBytes = 0 }));
         }
 
         [Test]
@@ -143,8 +149,8 @@ namespace Microsoft.IO.UnitTests
             {
                 var buffer = memMgr.GetLargeBuffer(i, DefaultId, DefaultTag);
                 Assert.That(buffer.Length >= i, Is.True);
-                Assert.That((buffer.Length % memMgr.LargeBufferMultiple) == 0, Is.True,
-                            "buffer length of {0} is not a multiple of {1}", buffer.Length, memMgr.LargeBufferMultiple);
+                Assert.That((buffer.Length % memMgr.options.LargeBufferMultiple) == 0, Is.True,
+                            "buffer length of {0} is not a multiple of {1}", buffer.Length, memMgr.options.LargeBufferMultiple);
             }
         }
 
@@ -157,8 +163,15 @@ namespace Microsoft.IO.UnitTests
 
             for (var size = LargeBufferMultiple; size <= MaxBufferSize; size += LargeBufferMultiple)
             {
-                var memMgr = new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize, this.UseExponentialLargeBuffer)
-                             {AggressiveBufferReturn = this.AggressiveBufferRelease};
+                var memMgr = new RecyclableMemoryStreamManager(
+                    new RecyclableMemoryStreamManager.Options
+                    {
+                        BlockSize = BlockSize,
+                        LargeBufferMultiple = LargeBufferMultiple,
+                        MaximumBufferSize = MaxBufferSize,
+                        UseExponentialLargeBuffer = this.UseExponentialLargeBuffer,
+                        AggressiveBufferReturn = this.AggressiveBufferRelease
+                    });
                 var buffer = memMgr.GetLargeBuffer(size, DefaultId, DefaultTag);
                 Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
                 Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(size));
@@ -179,8 +192,8 @@ namespace Microsoft.IO.UnitTests
             logger.SubscribeToEvents(Events.Writer, EventLevel.Verbose);
 
             var memMgr = GetMemoryManager();
-            memMgr.GenerateCallStacks = true;
-            var buffer = memMgr.GetLargeBuffer(memMgr.MaximumBufferSize + 1, DefaultTag);
+            memMgr.options.GenerateCallStacks = true;
+            var buffer = memMgr.GetLargeBuffer(memMgr.options.MaximumBufferSize + 1, DefaultTag);
             // wait for log to flush
             GC.Collect(1);
             GC.WaitForPendingFinalizers();
@@ -226,7 +239,7 @@ namespace Microsoft.IO.UnitTests
         public void ReturnBlockWithInvalidBufferThrowsException()
         {
             var memMgr = this.GetMemoryManager();
-            var buffer = new byte[memMgr.BlockSize + 1];
+            var buffer = new byte[memMgr.options.BlockSize + 1];
             Assert.Throws<ArgumentException>(() => memMgr.ReturnBlock(buffer, Guid.Empty, string.Empty));
         }
 
@@ -236,7 +249,7 @@ namespace Microsoft.IO.UnitTests
             var buffers = new List<byte[]>(3);
             var memMgr = this.GetMemoryManager();
             buffers.Add(memMgr.GetBlock());
-            buffers.Add(new byte[memMgr.BlockSize + 1]);
+            buffers.Add(new byte[memMgr.options.BlockSize + 1]);
             buffers.Add(memMgr.GetBlock());
             Assert.Throws<ArgumentException>(() => memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty));
         }
@@ -256,8 +269,8 @@ namespace Microsoft.IO.UnitTests
         public virtual void RequestTooLargeBufferAdjustsInUseCounter()
         {
             var memMgr = this.GetMemoryManager();
-            var buffer = memMgr.GetLargeBuffer(memMgr.MaximumBufferSize + 1, DefaultId, DefaultTag);
-            Assert.That(buffer.Length, Is.EqualTo(memMgr.MaximumBufferSize + memMgr.LargeBufferMultiple));
+            var buffer = memMgr.GetLargeBuffer(memMgr.options.MaximumBufferSize + 1, DefaultId, DefaultTag);
+            Assert.That(buffer.Length, Is.EqualTo(memMgr.options.MaximumBufferSize + memMgr.options.LargeBufferMultiple));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(buffer.Length));
         }
 
@@ -265,7 +278,7 @@ namespace Microsoft.IO.UnitTests
         public void ReturnTooLargeBufferDoesNotReturnToPool()
         {
             var memMgr = this.GetMemoryManager();
-            var buffer = memMgr.GetLargeBuffer(memMgr.MaximumBufferSize + 1, DefaultId, DefaultTag);
+            var buffer = memMgr.GetLargeBuffer(memMgr.options.MaximumBufferSize + 1, DefaultId, DefaultTag);
 
             memMgr.ReturnLargeBuffer(buffer, DefaultId, DefaultTag);
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(0));
@@ -288,7 +301,7 @@ namespace Microsoft.IO.UnitTests
             const int BuffersToTest = MaxFreeBuffersAllowed + 1;
 
             // Only allow 2 blocks in the free pool at a time
-            memMgr.MaximumFreeSmallPoolBytes = MaxFreeBuffersAllowed * memMgr.BlockSize;
+            memMgr.options.MaximumSmallPoolFreeBytes = MaxFreeBuffersAllowed * memMgr.options.BlockSize;
             var buffers = new List<byte[]>(BuffersToTest);
             for (var i = buffers.Capacity; i > 0; --i)
             {
@@ -296,14 +309,14 @@ namespace Microsoft.IO.UnitTests
             }
 
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
 
             // All but one buffer should be returned to pool
             for (int i = 0; i < buffers.Count; i++)
             {
                 memMgr.ReturnBlock(buffers[i], Guid.Empty, string.Empty);
             }
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.MaximumFreeSmallPoolBytes));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.MaximumSmallPoolFreeBytes));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
 
@@ -315,7 +328,7 @@ namespace Microsoft.IO.UnitTests
             const int BuffersToTest = MaxFreeBuffersAllowed + 1;
 
             // Only allow 2 blocks in the free pool at a time
-            memMgr.MaximumFreeSmallPoolBytes = MaxFreeBuffersAllowed * memMgr.BlockSize;
+            memMgr.options.MaximumSmallPoolFreeBytes = MaxFreeBuffersAllowed * memMgr.options.BlockSize;
             var buffers = new List<byte[]>(BuffersToTest);
             for (var i = buffers.Capacity; i>0 ; --i)
             {
@@ -323,11 +336,11 @@ namespace Microsoft.IO.UnitTests
             }
 
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
 
             // All but one buffer should be returned to pool
             memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty);
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.MaximumFreeSmallPoolBytes));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.MaximumSmallPoolFreeBytes));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
 
@@ -338,7 +351,7 @@ namespace Microsoft.IO.UnitTests
 
             const int BuffersToTest = 99;
 
-            memMgr.MaximumFreeSmallPoolBytes = 0;
+            memMgr.options.MaximumSmallPoolFreeBytes = 0;
             var buffers = new List<byte[]>(BuffersToTest);
             for (var i = buffers.Capacity; i > 0; --i)
             {
@@ -346,10 +359,10 @@ namespace Microsoft.IO.UnitTests
             }
 
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
 
             memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty);
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(BuffersToTest * memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
 
@@ -373,11 +386,16 @@ namespace Microsoft.IO.UnitTests
 
             for (var size = LargeBufferMultiple; size <= MaxBufferSize; size += LargeBufferMultiple)
             {
-                var memMgr = new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize, this.UseExponentialLargeBuffer)
-                             {
-                                 AggressiveBufferReturn = this.AggressiveBufferRelease,
-                                 MaximumFreeLargePoolBytes = maxFreeLargeBufferSize
-                             };
+                var memMgr = new RecyclableMemoryStreamManager(
+                    new RecyclableMemoryStreamManager.Options
+                    {
+                        BlockSize = BlockSize,
+                        LargeBufferMultiple = LargeBufferMultiple,
+                        MaximumBufferSize = MaxBufferSize,
+                        UseExponentialLargeBuffer = this.UseExponentialLargeBuffer,
+                        AggressiveBufferReturn = this.AggressiveBufferRelease,
+                        MaximumLargePoolFreeBytes = maxFreeLargeBufferSize
+                    });
 
                 var buffers = new List<byte[]>();
 
@@ -416,22 +434,22 @@ namespace Microsoft.IO.UnitTests
             var block = memMgr.GetBlock();
 
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.BlockSize));
 
             memMgr.ReturnBlocks(new List<byte[]> {block}, Guid.Empty, string.Empty);
 
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
 
             // This should get an existing block
             block = memMgr.GetBlock();
 
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.BlockSize));
 
             memMgr.ReturnBlocks(new List<byte[]> {block}, Guid.Empty, string.Empty);
 
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
         #endregion
@@ -441,11 +459,11 @@ namespace Microsoft.IO.UnitTests
         public void GetBufferReturnsSingleBlockForBlockSize()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize;
+            var size = stream.MemoryManager.options.BlockSize;
             var buffer = this.GetRandomBuffer(size);
             stream.Write(buffer, 0, buffer.Length);
             var returnedBuffer = stream.GetBuffer();
-            Assert.That(returnedBuffer.Length, Is.EqualTo(stream.MemoryManager.BlockSize));
+            Assert.That(returnedBuffer.Length, Is.EqualTo(stream.MemoryManager.options.BlockSize));
             RMSAssert.TryGetBufferEqualToGetBuffer(stream);
         }
 
@@ -453,11 +471,11 @@ namespace Microsoft.IO.UnitTests
         public void GetBufferReturnsSingleBlockForLessThanBlockSize()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize - 1;
+            var size = stream.MemoryManager.options.BlockSize - 1;
             var buffer = this.GetRandomBuffer(size);
             stream.Write(buffer, 0, buffer.Length);
             var returnedBuffer = stream.GetBuffer();
-            Assert.That(returnedBuffer.Length, Is.EqualTo(stream.MemoryManager.BlockSize));
+            Assert.That(returnedBuffer.Length, Is.EqualTo(stream.MemoryManager.options.BlockSize));
             RMSAssert.TryGetBufferEqualToGetBuffer(stream);
         }
 
@@ -465,11 +483,11 @@ namespace Microsoft.IO.UnitTests
         public void GetBufferReturnsLargeBufferForMoreThanBlockSize()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize + 1;
+            var size = stream.MemoryManager.options.BlockSize + 1;
             var buffer = this.GetRandomBuffer(size);
             stream.Write(buffer, 0, buffer.Length);
             var returnedBuffer = stream.GetBuffer();
-            Assert.That(returnedBuffer.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(returnedBuffer.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
             RMSAssert.TryGetBufferEqualToGetBuffer(stream);
         }
 
@@ -477,7 +495,7 @@ namespace Microsoft.IO.UnitTests
         public void GetBufferReturnsSameLarge()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             var returnedBuffer = stream.GetBuffer();
             var returnedBuffer2 = stream.GetBuffer();
@@ -490,7 +508,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var memMgr = stream.MemoryManager;
-            var bufferLength = stream.MemoryManager.BlockSize * 4;
+            var bufferLength = stream.MemoryManager.options.BlockSize * 4;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, buffer.Length);
 
@@ -532,19 +550,19 @@ namespace Microsoft.IO.UnitTests
         public void CallingWriteAfterLargeGetBufferDoesNotLoseData()
         {
             var stream = this.GetDefaultStream();
-            stream.Capacity = stream.MemoryManager.BlockSize + 1;
+            stream.Capacity = stream.MemoryManager.options.BlockSize + 1;
             var buffer = stream.GetBuffer();
-            buffer[stream.MemoryManager.BlockSize] = 13;
+            buffer[stream.MemoryManager.options.BlockSize] = 13;
 
-            stream.Position = stream.MemoryManager.BlockSize + 1;
+            stream.Position = stream.MemoryManager.options.BlockSize + 1;
             var bytesToWrite = this.GetRandomBuffer(10);
             stream.Write(bytesToWrite, 0, bytesToWrite.Length);
 
             buffer = stream.GetBuffer();
 
-            Assert.That(buffer[stream.MemoryManager.BlockSize], Is.EqualTo(13));
-            RMSAssert.BuffersAreEqual(buffer, stream.MemoryManager.BlockSize + 1, bytesToWrite, 0, bytesToWrite.Length);
-            Assert.That(stream.Position, Is.EqualTo(stream.MemoryManager.BlockSize + 1 + bytesToWrite.Length));
+            Assert.That(buffer[stream.MemoryManager.options.BlockSize], Is.EqualTo(13));
+            RMSAssert.BuffersAreEqual(buffer, stream.MemoryManager.options.BlockSize + 1, bytesToWrite, 0, bytesToWrite.Length);
+            Assert.That(stream.Position, Is.EqualTo(stream.MemoryManager.options.BlockSize + 1 + bytesToWrite.Length));
             RMSAssert.TryGetBufferEqualToGetBuffer(stream);
         }
 
@@ -552,18 +570,18 @@ namespace Microsoft.IO.UnitTests
         public void CallingWriteByteAfterLargeGetBufferDoesNotLoseData()
         {
             var stream = this.GetDefaultStream();
-            stream.Capacity = stream.MemoryManager.BlockSize + 1;
+            stream.Capacity = stream.MemoryManager.options.BlockSize + 1;
             var buffer = stream.GetBuffer();
-            buffer[stream.MemoryManager.BlockSize] = 13;
+            buffer[stream.MemoryManager.options.BlockSize] = 13;
 
-            stream.Position = stream.MemoryManager.BlockSize + 1;
+            stream.Position = stream.MemoryManager.options.BlockSize + 1;
             stream.WriteByte(14);
 
             buffer = stream.GetBuffer();
 
-            Assert.That(buffer[stream.MemoryManager.BlockSize], Is.EqualTo(13));
-            Assert.That(buffer[stream.MemoryManager.BlockSize + 1], Is.EqualTo(14));
-            Assert.That(stream.Position, Is.EqualTo(stream.MemoryManager.BlockSize + 2));
+            Assert.That(buffer[stream.MemoryManager.options.BlockSize], Is.EqualTo(13));
+            Assert.That(buffer[stream.MemoryManager.options.BlockSize + 1], Is.EqualTo(14));
+            Assert.That(stream.Position, Is.EqualTo(stream.MemoryManager.options.BlockSize + 2));
             RMSAssert.TryGetBufferEqualToGetBuffer(stream);
         }
 
@@ -574,7 +592,7 @@ namespace Microsoft.IO.UnitTests
 
             for (var i = -1; i < 2; ++i)
             {
-                int requestedSize = int.MaxValue - (mgr.BlockSize + i);
+                int requestedSize = int.MaxValue - (mgr.options.BlockSize + i);
                 var stream = mgr.GetStream(null, requestedSize);
                 Assert.That(stream.Capacity64, Is.GreaterThanOrEqualTo(requestedSize));
             }
@@ -607,7 +625,7 @@ namespace Microsoft.IO.UnitTests
         public void GetSpanMemoryWithHintLargerThanMaximumStreamCapacityFails()
         {
             var memoryManager = this.GetMemoryManager();
-            memoryManager.MaximumStreamCapacity = short.MaxValue;
+            memoryManager.options.MaximumStreamCapacity = short.MaxValue;
             var stream = new RecyclableMemoryStream(memoryManager, string.Empty, 0);
             Assert.Throws<OutOfMemoryException>(() => stream.GetSpan(short.MaxValue + 1));
             Assert.Throws<OutOfMemoryException>(() => stream.GetMemory(short.MaxValue + 1));
@@ -629,7 +647,7 @@ namespace Microsoft.IO.UnitTests
         public void GetSpanMemoryReturnsLargeBufferWithNoHint()
         {
             var stream = this.GetDefaultStream();
-            stream.Capacity = stream.MemoryManager.BlockSize + 1;
+            stream.Capacity = stream.MemoryManager.options.BlockSize + 1;
             var buffer = stream.GetBuffer();
             var span = stream.GetSpan();
             var memory = stream.GetMemory();
@@ -658,7 +676,7 @@ namespace Microsoft.IO.UnitTests
         public void GetSpanMemoryReturnsNewBlockWithNoHintPositionedEndOfBlock()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize;
+            var size = stream.MemoryManager.options.BlockSize;
 
             stream.Position = size;
             var span = stream.GetSpan();
@@ -680,7 +698,7 @@ namespace Microsoft.IO.UnitTests
         public void GetSpanMemoryReturnsLargeTempBufferWhenHintIsLongerThanBlock()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize + 1;
+            var size = stream.MemoryManager.options.BlockSize + 1;
 
             var span = stream.GetSpan(size + 1);
             byte[] randomBuffer = this.GetRandomBuffer(size);
@@ -690,14 +708,14 @@ namespace Microsoft.IO.UnitTests
             Span<byte> bufferSpan = stream.GetBuffer().AsSpan(0, size);
             Assert.IsTrue(bufferSpan.SequenceEqual(randomBuffer));
             Assert.IsFalse(bufferSpan == span);
-            Assert.AreEqual(stream.MemoryManager.LargeBufferMultiple, span.Length);
+            Assert.AreEqual(stream.MemoryManager.options.LargeBufferMultiple, span.Length);
         }
 
         [Test]
         public void GetSpanMemoryReturnsBlockTempBufferWhenHintGoesPastEndOfBlock()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize / 2;
+            var size = stream.MemoryManager.options.BlockSize / 2;
 
             stream.Position = size + 1;
             var span = stream.GetSpan(size);
@@ -708,7 +726,7 @@ namespace Microsoft.IO.UnitTests
             Span<byte> bufferSpan = stream.GetBuffer().AsSpan(size + 1, size);
             Assert.IsTrue(bufferSpan.SequenceEqual(randomBuffer));
             Assert.IsFalse(bufferSpan == span);
-            Assert.AreEqual(stream.MemoryManager.BlockSize, span.Length);
+            Assert.AreEqual(stream.MemoryManager.options.BlockSize, span.Length);
         }
         #endregion
 
@@ -717,13 +735,13 @@ namespace Microsoft.IO.UnitTests
         public void GetReadOnlySequenceReturnsSingleBlockForBlockSize()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize;
+            var size = stream.MemoryManager.options.BlockSize;
             var buffer = this.GetRandomBuffer(size);
             stream.Write(buffer, 0, buffer.Length);
             var returnedSequence = stream.GetReadOnlySequence();
             Assert.That(returnedSequence.IsSingleSegment);
-            Assert.That(returnedSequence.Length, Is.EqualTo(stream.MemoryManager.BlockSize));
-            Assert.That(returnedSequence.First.Length, Is.EqualTo(stream.MemoryManager.BlockSize));
+            Assert.That(returnedSequence.Length, Is.EqualTo(stream.MemoryManager.options.BlockSize));
+            Assert.That(returnedSequence.First.Length, Is.EqualTo(stream.MemoryManager.options.BlockSize));
             Assert.That(MemoryMarshal.TryGetArray(returnedSequence.First, out ArraySegment<byte> arraySegment), Is.True);
             RMSAssert.BuffersAreEqual(arraySegment.Array, stream.GetBuffer(), stream.GetBuffer().Length);
         }
@@ -732,7 +750,7 @@ namespace Microsoft.IO.UnitTests
         public void GetReadOnlySequenceReturnsSingleBlockForLessThanBlockSize()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize - 1;
+            var size = stream.MemoryManager.options.BlockSize - 1;
             var buffer = this.GetRandomBuffer(size);
             stream.Write(buffer, 0, buffer.Length);
             var returnedSequence = stream.GetReadOnlySequence();
@@ -747,16 +765,16 @@ namespace Microsoft.IO.UnitTests
         public void GetReadOnlySequenceReturnsMultipleBuffersForMoreThanBlockSize()
         {
             var stream = this.GetDefaultStream();
-            var size = stream.MemoryManager.BlockSize + 1;
+            var size = stream.MemoryManager.options.BlockSize + 1;
             var buffer = this.GetRandomBuffer(size);
             stream.Write(buffer, 0, buffer.Length);
             var returnedSequence = stream.GetReadOnlySequence();
             stream.TryGetBuffer(out ArraySegment<byte> getBufferArraySegment);
             Assert.That(returnedSequence.IsSingleSegment, Is.False);
             Assert.That(returnedSequence.Length, Is.EqualTo(size));
-            Assert.That(returnedSequence.First.Length, Is.EqualTo(stream.MemoryManager.BlockSize));
-            Assert.That(returnedSequence.Slice(stream.MemoryManager.BlockSize).IsSingleSegment);
-            Assert.That(returnedSequence.Slice(stream.MemoryManager.BlockSize).Length, Is.EqualTo(1));
+            Assert.That(returnedSequence.First.Length, Is.EqualTo(stream.MemoryManager.options.BlockSize));
+            Assert.That(returnedSequence.Slice(stream.MemoryManager.options.BlockSize).IsSingleSegment);
+            Assert.That(returnedSequence.Slice(stream.MemoryManager.options.BlockSize).Length, Is.EqualTo(1));
             RMSAssert.BuffersAreEqual(returnedSequence.ToArray(), getBufferArraySegment, (int)returnedSequence.Length);
         }
 
@@ -764,13 +782,13 @@ namespace Microsoft.IO.UnitTests
         public void GetReadOnlySequenceReturnsLargeAfterGetBuffer()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             stream.TryGetBuffer(out ArraySegment<byte> getBufferArraySegment);
             var returnedSequence = stream.GetReadOnlySequence();
             Assert.That(returnedSequence.IsSingleSegment);
-            Assert.That(returnedSequence.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
-            Assert.That(returnedSequence.First.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(returnedSequence.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
+            Assert.That(returnedSequence.First.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
             Assert.That(MemoryMarshal.TryGetArray(returnedSequence.First, out ArraySegment<byte> sequenceArraySegment));
             RMSAssert.BuffersAreEqual(returnedSequence.ToArray(), getBufferArraySegment, (int)returnedSequence.Length);
         }
@@ -779,7 +797,7 @@ namespace Microsoft.IO.UnitTests
         public void GetReadOnlySequenceReturnsSameLarge()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             stream.TryGetBuffer(out ArraySegment<byte> arraySegment0);
             var returnedSequence1 = stream.GetReadOnlySequence();
@@ -843,17 +861,17 @@ namespace Microsoft.IO.UnitTests
         {
             var memoryManager = this.GetMemoryManager();
             var stream = new RecyclableMemoryStream(memoryManager);
-            Assert.That(stream.Capacity, Is.EqualTo(memoryManager.BlockSize));
+            Assert.That(stream.Capacity, Is.EqualTo(memoryManager.options.BlockSize));
         }
 
         [Test]
         public void ActualCapacityAtLeastRequestedCapacityAndMultipleOfBlockSize()
         {
             var memoryManager = this.GetMemoryManager();
-            var requestedSize = memoryManager.BlockSize + 1;
+            var requestedSize = memoryManager.options.BlockSize + 1;
             var stream = new RecyclableMemoryStream(memoryManager, string.Empty, requestedSize);
             Assert.That(stream.Capacity, Is.GreaterThanOrEqualTo(requestedSize));
-            Assert.That(stream.Capacity % memoryManager.BlockSize == 0, Is.True,
+            Assert.That(stream.Capacity % memoryManager.options.BlockSize == 0, Is.True,
                         "stream capacity is not a multiple of the block size");
         }
 
@@ -861,7 +879,7 @@ namespace Microsoft.IO.UnitTests
         public void IdTagAndRequestedSizeSet()
         {
             var memoryManager = this.GetMemoryManager();
-            var requestedSize = memoryManager.BlockSize + 1;
+            var requestedSize = memoryManager.options.BlockSize + 1;
             var expectedGuid = Guid.NewGuid();
             var stream = new RecyclableMemoryStream(memoryManager, expectedGuid, "Tag", requestedSize);
             Assert.That(stream.Id, Is.EqualTo(expectedGuid));
@@ -874,14 +892,14 @@ namespace Microsoft.IO.UnitTests
         public void AllocationStackIsRecorded()
         {
             var memMgr = this.GetMemoryManager();
-            memMgr.GenerateCallStacks = true;
+            memMgr.options.GenerateCallStacks = true;
 
             var stream = new RecyclableMemoryStream(memMgr);
 
             Assert.That(stream.AllocationStack, Does.Contain("RecyclableMemoryStream..ctor"));
             stream.Dispose();
 
-            memMgr.GenerateCallStacks = false;
+            memMgr.options.GenerateCallStacks = false;
 
             var stream2 = new RecyclableMemoryStream(memMgr);
 
@@ -932,7 +950,7 @@ namespace Microsoft.IO.UnitTests
         public void WriteLargeBufferStoresDataCorrectly()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize + 1);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize + 1);
             stream.Write(buffer, 0, buffer.Length);
             RMSAssert.BuffersAreEqual(buffer, stream.GetBuffer(), buffer.Length);
         }
@@ -954,23 +972,23 @@ namespace Microsoft.IO.UnitTests
         public void WritePastEndOfLargeBufferIncreasesCapacityAndCopiesBuffer()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             var get1 = stream.GetBuffer();
-            Assert.That(get1.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(get1.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
             stream.Write(buffer, 0, 1);
             var get2 = stream.GetBuffer();
-            Assert.That(stream.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple + 1));
-            Assert.That(get2.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple * 2));
+            Assert.That(stream.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple + 1));
+            Assert.That(get2.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple * 2));
             RMSAssert.BuffersAreEqual(get1, get2, (int)stream.Length - 1);
-            Assert.That(get2[stream.MemoryManager.LargeBufferMultiple], Is.EqualTo(buffer[0]));
+            Assert.That(get2[stream.MemoryManager.options.LargeBufferMultiple], Is.EqualTo(buffer[0]));
         }
 
         [Test]
         public void WriteAfterLargeBufferDoesNotAllocateMoreBlocks()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize + 1);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize + 1);
             stream.Write(buffer, 0, buffer.Length);
             var inUseBlockBytes = stream.MemoryManager.SmallPoolInUseSize;
             stream.GetBuffer();
@@ -1037,7 +1055,7 @@ namespace Microsoft.IO.UnitTests
         public void WriteUpdatesPosition()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.BlockSize / 2 + 1;
+            var bufferLength = stream.MemoryManager.options.BlockSize / 2 + 1;
             var buffer = this.GetRandomBuffer(bufferLength);
 
             for (var i = 0; i < 10; ++i)
@@ -1103,7 +1121,7 @@ namespace Microsoft.IO.UnitTests
         public void WriteSpanLargeBufferStoresDataCorrectly()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize + 1);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize + 1);
             stream.Write(buffer.AsSpan());
             RMSAssert.BuffersAreEqual(buffer, stream.GetBuffer(), buffer.Length);
         }
@@ -1125,23 +1143,23 @@ namespace Microsoft.IO.UnitTests
         public void WriteSpanPastEndOfLargeBufferIncreasesCapacityAndCopiesBuffer()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer.AsSpan());
             var get1 = stream.GetBuffer();
-            Assert.That(get1.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(get1.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
             stream.Write(buffer.AsSpan(0, 1));
             var get2 = stream.GetBuffer();
-            Assert.That(stream.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple + 1));
-            Assert.That(get2.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple * 2));
+            Assert.That(stream.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple + 1));
+            Assert.That(get2.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple * 2));
             RMSAssert.BuffersAreEqual(get1, get2, (int)stream.Length - 1);
-            Assert.That(get2[stream.MemoryManager.LargeBufferMultiple], Is.EqualTo(buffer[0]));
+            Assert.That(get2[stream.MemoryManager.options.LargeBufferMultiple], Is.EqualTo(buffer[0]));
         }
 
         [Test]
         public void WriteSpanAfterLargeBufferDoesNotAllocateMoreBlocks()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize + 1);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize + 1);
             stream.Write(buffer.AsSpan());
             var inUseBlockBytes = stream.MemoryManager.SmallPoolInUseSize;
             stream.GetBuffer();
@@ -1157,7 +1175,7 @@ namespace Microsoft.IO.UnitTests
         public void WriteSpanUpdatesPosition()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.BlockSize / 2 + 1;
+            var bufferLength = stream.MemoryManager.options.BlockSize / 2 + 1;
             var buffer = this.GetRandomBuffer(bufferLength);
 
             for (var i = 0; i < 10; ++i)
@@ -1300,15 +1318,15 @@ namespace Microsoft.IO.UnitTests
         public void WriteByteAtEndOfLargeBufferIncreasesCapacity()
         {
             var stream = this.GetDefaultStream();
-            stream.Capacity = stream.MemoryManager.BlockSize * 2;
+            stream.Capacity = stream.MemoryManager.options.BlockSize * 2;
             var bufferLength = stream.Capacity;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, bufferLength);
             stream.GetBuffer();
-            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
-            stream.Position = stream.MemoryManager.LargeBufferMultiple;
+            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
+            stream.Position = stream.MemoryManager.options.LargeBufferMultiple;
             stream.WriteByte(255);
-            Assert.That(stream.Capacity, Is.GreaterThan(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(stream.Capacity, Is.GreaterThan(stream.MemoryManager.options.LargeBufferMultiple));
         }
         #endregion
 
@@ -1368,14 +1386,14 @@ namespace Microsoft.IO.UnitTests
         [Test]
         public void SafeReadByte_BlocksAndLargeBufferSame()
         {
-            var buffer = this.GetRandomBuffer(this.GetMemoryManager().BlockSize * 2);
+            var buffer = this.GetRandomBuffer(this.GetMemoryManager().options.BlockSize * 2);
             var stream1 = this.GetDefaultStream();
             var stream2 = this.GetDefaultStream();
             stream1.Write(buffer);
             stream2.Write(buffer);
             stream2.GetBuffer();
-            Assert.That(stream1.Capacity, Is.EqualTo(stream1.MemoryManager.BlockSize * 2));
-            Assert.That(stream2.Capacity, Is.EqualTo(stream2.MemoryManager.LargeBufferMultiple));
+            Assert.That(stream1.Capacity, Is.EqualTo(stream1.MemoryManager.options.BlockSize * 2));
+            Assert.That(stream2.Capacity, Is.EqualTo(stream2.MemoryManager.options.LargeBufferMultiple));
 
             for (var i = 0L; i < stream1.Length; i++)
             {
@@ -1420,7 +1438,7 @@ namespace Microsoft.IO.UnitTests
         public void ReadByteReturnsCorrectValueFromBlocks()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize);
             stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
             for (var i = 0; i < stream.Length; i++)
@@ -1434,7 +1452,7 @@ namespace Microsoft.IO.UnitTests
         public void ReadByteReturnsCorrectValueFromLargeBuffer()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
             var copy = new byte[buffer.Length];
@@ -1453,7 +1471,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetRandomStream();
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var bytesRead = 0;
             var position = 0L;
@@ -1474,7 +1492,7 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, bufferLength);
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var expected = new byte[step];
             var bytesRead = 0;
@@ -1502,8 +1520,8 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, bufferLength);
 
-            var stepSlow = stream.MemoryManager.BlockSize / 4;
-            var stepFast = stream.MemoryManager.BlockSize / 2;
+            var stepSlow = stream.MemoryManager.options.BlockSize / 4;
+            var stepFast = stream.MemoryManager.options.BlockSize / 2;
             var readBuffer = new byte[stepFast];
             var readSlow = new MemoryStream();
             var readFast = new MemoryStream();
@@ -1558,7 +1576,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetRandomStream();
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var bytesRead = 0;
             long position = 0;
@@ -1578,7 +1596,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetRandomStream();
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var bytesRead = 0;
             var position = 0L;
@@ -1599,7 +1617,7 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, bufferLength);
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var expected = new byte[step];
             var bytesRead = 0;
@@ -1627,8 +1645,8 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, bufferLength);
 
-            var stepSlow = stream.MemoryManager.BlockSize / 4;
-            var stepFast = stream.MemoryManager.BlockSize / 2;
+            var stepSlow = stream.MemoryManager.options.BlockSize / 4;
+            var stepFast = stream.MemoryManager.options.BlockSize / 2;
             var readBuffer = new byte[stepFast];
             var readSlow = new MemoryStream();
             var readFast = new MemoryStream();
@@ -1819,7 +1837,7 @@ namespace Microsoft.IO.UnitTests
 
             stream.Position = 0;
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var bytesRead = 0;
             while (stream.Position < stream.Length)
@@ -1847,7 +1865,7 @@ namespace Microsoft.IO.UnitTests
         public void ReadPastEndOfLargeBufferIsOk()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.LargeBufferMultiple;
+            var bufferLength = stream.MemoryManager.options.LargeBufferMultiple;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, buffer.Length);
 
@@ -1964,7 +1982,7 @@ namespace Microsoft.IO.UnitTests
 
             stream.Position = 0;
 
-            var step = stream.MemoryManager.BlockSize / 2;
+            var step = stream.MemoryManager.options.BlockSize / 2;
             var destBuffer = new byte[step];
             var bytesRead = 0;
             while (stream.Position < stream.Length)
@@ -1992,7 +2010,7 @@ namespace Microsoft.IO.UnitTests
         public void ReadSpanPastEndOfLargeBufferIsOk()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.LargeBufferMultiple;
+            var bufferLength = stream.MemoryManager.options.LargeBufferMultiple;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer.AsSpan());
 
@@ -2027,7 +2045,7 @@ namespace Microsoft.IO.UnitTests
             for (var i = 0; i < 100; i++)
             {
                 stream.Capacity += step;
-                Assert.That(stream.Capacity % stream.MemoryManager.BlockSize, Is.EqualTo(0));
+                Assert.That(stream.Capacity % stream.MemoryManager.options.BlockSize, Is.EqualTo(0));
             }
         }
 
@@ -2047,31 +2065,31 @@ namespace Microsoft.IO.UnitTests
         public void CapacityGoesLargeWhenLargeGetBufferCalled()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize);
             stream.Write(buffer, 0, buffer.Length);
-            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.BlockSize));
+            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.options.BlockSize));
             stream.Write(buffer, 0, buffer.Length);
             stream.GetBuffer();
-            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
-            Assert.That(stream.Capacity64, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
+            Assert.That(stream.Capacity64, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
         }
 
         [Test]
         public void EnsureCapacityOperatesOnLargeBufferWhenNeeded()
         {
             var stream = this.GetDefaultStream();
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.BlockSize);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize);
             stream.Write(buffer, 0, buffer.Length);
             stream.Write(buffer, 0, buffer.Length);
             stream.GetBuffer();
 
             // At this point, we're not longer using blocks, just large buffers
-            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
 
             // this should bump up the capacity by the LargeBufferMultiple
-            stream.Capacity = stream.MemoryManager.LargeBufferMultiple + 1;
+            stream.Capacity = stream.MemoryManager.options.LargeBufferMultiple + 1;
 
-            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple * 2));
+            Assert.That(stream.Capacity, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple * 2));
         }
 
         [Test]
@@ -2172,6 +2190,17 @@ namespace Microsoft.IO.UnitTests
             Assert.That(debugInfo, Contains.Substring(stream.Id.ToString()));
             Assert.That(debugInfo, Contains.Substring(buffer.Length.ToString("N0")));
         }
+
+        [Test]
+        public void ToStringOnDisposedOk()
+        {
+            var guid = Guid.NewGuid();
+            var tag = "NUnit";
+            var stream = new RecyclableMemoryStream(this.GetMemoryManager(), guid, tag);
+            stream.WriteByte(1);
+            stream.Dispose();
+            Assert.That(stream.ToString(), Is.EqualTo($"Disposed: Id = {guid}, Tag = {tag}, Final Length: 1 bytes"));
+        }
         #endregion
 
         #region ToArray Tests
@@ -2194,7 +2223,7 @@ namespace Microsoft.IO.UnitTests
         public void ToArrayWithLargeBufferReturnsDifferentBufferThanGetBufferWithSameContents()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.BlockSize * 2;
+            var bufferLength = stream.MemoryManager.options.BlockSize * 2;
             var buffer = this.GetRandomBuffer(bufferLength);
 
             stream.Write(buffer, 0, bufferLength);
@@ -2209,7 +2238,7 @@ namespace Microsoft.IO.UnitTests
         public void ToArrayThrowsExceptionWhenConfigured()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.BlockSize * 2;
+            var bufferLength = stream.MemoryManager.options.BlockSize * 2;
             var buffer = this.GetRandomBuffer(bufferLength);
 
             stream.Write(buffer, 0, bufferLength);
@@ -2217,10 +2246,10 @@ namespace Microsoft.IO.UnitTests
             // Ensure default is false
             Assert.DoesNotThrow(() => stream.ToArray());
 
-            stream.MemoryManager.ThrowExceptionOnToArray = true;
+            stream.MemoryManager.options.ThrowExceptionOnToArray = true;
             Assert.Throws<NotSupportedException>(() => stream.ToArray());
 
-            stream.MemoryManager.ThrowExceptionOnToArray = false;
+            stream.MemoryManager.options.ThrowExceptionOnToArray = false;
             Assert.DoesNotThrow(() => stream.ToArray());
         }
         #endregion
@@ -2379,7 +2408,7 @@ namespace Microsoft.IO.UnitTests
         public void AdvancePastTempBufferLengthThrowsException()
         {
             var stream = this.GetDefaultStream();
-            var memory = stream.GetMemory(stream.MemoryManager.BlockSize + 1);
+            var memory = stream.GetMemory(stream.MemoryManager.options.BlockSize + 1);
             Assert.Throws<InvalidOperationException>(() => stream.Advance(memory.Length + 1));
         }
 
@@ -2395,7 +2424,7 @@ namespace Microsoft.IO.UnitTests
         public void AdvancePastLargeBufferLengthThrowsException()
         {
             var stream = this.GetDefaultStream();
-            stream.Position = stream.MemoryManager.BlockSize + 1;
+            stream.Position = stream.MemoryManager.options.BlockSize + 1;
             stream.GetBuffer();
             var memory = stream.GetMemory();
             Assert.Throws<InvalidOperationException>(() => stream.Advance(memory.Length + 1));
@@ -2430,7 +2459,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var buffer = this.GetRandomBuffer(32);
-            var memory = stream.GetMemory(stream.MemoryManager.BlockSize + 1);
+            var memory = stream.GetMemory(stream.MemoryManager.options.BlockSize + 1);
             buffer.CopyTo(memory);
             Assert.That(stream.GetBuffer().AsMemory(0, 32).ToArray(), Is.Not.EquivalentTo(buffer));
             stream.Advance(buffer.Length);
@@ -2443,9 +2472,9 @@ namespace Microsoft.IO.UnitTests
             var stream = this.GetDefaultStream();
             var buffer1 = this.GetRandomBuffer(32);
             var buffer2 = this.GetRandomBuffer(32);
-            var memory = stream.GetMemory(stream.MemoryManager.BlockSize + 1);
+            var memory = stream.GetMemory(stream.MemoryManager.options.BlockSize + 1);
             buffer1.CopyTo(memory);
-            memory = stream.GetMemory(stream.MemoryManager.BlockSize + 1);
+            memory = stream.GetMemory(stream.MemoryManager.options.BlockSize + 1);
             buffer2.CopyTo(memory);
             stream.Advance(buffer2.Length);
             Assert.That(stream.GetBuffer().AsMemory(0, 32).ToArray(), Is.Not.EquivalentTo(buffer1));
@@ -2472,8 +2501,8 @@ namespace Microsoft.IO.UnitTests
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
 
             var stream = new RecyclableMemoryStream(memMgr);
-            Assert.That(stream.Capacity, Is.EqualTo(memMgr.BlockSize));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(stream.Capacity, Is.EqualTo(memMgr.options.BlockSize));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
         }
 
@@ -2486,14 +2515,14 @@ namespace Microsoft.IO.UnitTests
 
             stream.Dispose();
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.BlockSize));
         }
 
         [Test]
         public void Pooling_DisposeMultipleBlocksAdjustsInUseAndFreeBytes()
         {
             var stream = this.GetDefaultStream();
-            var bufferLength = stream.MemoryManager.BlockSize * 4;
+            var bufferLength = stream.MemoryManager.options.BlockSize * 4;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, buffer.Length);
 
@@ -2511,7 +2540,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             const int numBlocks = 4;
-            var bufferLength = stream.MemoryManager.BlockSize * numBlocks;
+            var bufferLength = stream.MemoryManager.options.BlockSize * numBlocks;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, buffer.Length);
             var memMgr = stream.MemoryManager;
@@ -2524,11 +2553,11 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             const int numBlocks = 4;
-            var bufferLength = stream.MemoryManager.BlockSize * numBlocks;
+            var bufferLength = stream.MemoryManager.options.BlockSize * numBlocks;
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, buffer.Length);
             var newBuffer = stream.GetBuffer();
-            Assert.That(newBuffer.Length, Is.EqualTo(stream.MemoryManager.LargeBufferMultiple));
+            Assert.That(newBuffer.Length, Is.EqualTo(stream.MemoryManager.options.LargeBufferMultiple));
 
             Assert.That(stream.MemoryManager.LargeBuffersFree, Is.EqualTo(0));
             Assert.That(stream.MemoryManager.LargePoolFreeSize, Is.EqualTo(0));
@@ -2553,7 +2582,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var memMgr = stream.MemoryManager;
-            var bufferSize = stream.MemoryManager.MaximumBufferSize + 1;
+            var bufferSize = stream.MemoryManager.options.MaximumBufferSize + 1;
             var buffer = this.GetRandomBuffer(bufferSize);
             stream.Write(buffer, 0, buffer.Length);
             var newBuffer = stream.GetBuffer();
@@ -2654,7 +2683,7 @@ namespace Microsoft.IO.UnitTests
         {
             var memMgr = this.GetMemoryManager();
             var stream = memMgr.GetStream();
-            Assert.That(stream.Capacity, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(stream.Capacity, Is.EqualTo(memMgr.options.BlockSize));
         }
 
         [Test]
@@ -2663,7 +2692,7 @@ namespace Microsoft.IO.UnitTests
             var memMgr = this.GetMemoryManager();
             var tag = "MyTag";
             var stream = memMgr.GetStream(tag);
-            Assert.That(stream.Capacity, Is.EqualTo(memMgr.BlockSize));
+            Assert.That(stream.Capacity, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(stream.Tag, Is.EqualTo(tag));
         }
 
@@ -2967,7 +2996,7 @@ namespace Microsoft.IO.UnitTests
         public void MaximumStreamCapacity_NoLimit()
         {
             var stream = this.GetDefaultStream();
-            stream.MemoryManager.MaximumStreamCapacity = 0;
+            stream.MemoryManager.options.MaximumStreamCapacity = 0;
             stream.Capacity = (DefaultMaximumBufferSize * 2) + 1;
             Assert.That(stream.Capacity, Is.AtLeast((DefaultMaximumBufferSize * 2) + 1));
         }
@@ -2977,7 +3006,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var maxCapacity = DefaultMaximumBufferSize * 2;
-            stream.MemoryManager.MaximumStreamCapacity = maxCapacity;
+            stream.MemoryManager.options.MaximumStreamCapacity = maxCapacity;
             Assert.DoesNotThrow(() => stream.Capacity = maxCapacity);
             Assert.Throws<OutOfMemoryException>(() => stream.Capacity = maxCapacity + 1);
         }
@@ -2987,7 +3016,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var maxCapacity = DefaultMaximumBufferSize * 2;
-            stream.MemoryManager.MaximumStreamCapacity = maxCapacity;
+            stream.MemoryManager.options.MaximumStreamCapacity = maxCapacity;
             Assert.DoesNotThrow(() => stream.Capacity = maxCapacity);
             var oldCapacity = stream.Capacity;
             Assert.Throws<OutOfMemoryException>(() => stream.Capacity = maxCapacity + 1);
@@ -2999,7 +3028,7 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var maxCapacity = DefaultMaximumBufferSize * 2;
-            stream.MemoryManager.MaximumStreamCapacity = maxCapacity;
+            stream.MemoryManager.options.MaximumStreamCapacity = maxCapacity;
             var buffer1 = this.GetRandomBuffer(100);
             stream.Write(buffer1, 0, buffer1.Length);
             var oldLength = stream.Length;
@@ -3013,7 +3042,27 @@ namespace Microsoft.IO.UnitTests
         }
         #endregion
 
-		#region CopyToAsync Tests
+        #region CopyTo Tests
+
+        [Test]
+        public void CopyTo()
+        {
+            using var stream = GetDefaultStream();
+            var buffer = GetRandomBuffer(100);
+            stream.Write(buffer);
+
+            using var memoryStream = new MemoryStream();
+            stream.Position = 0;
+            stream.CopyTo(memoryStream, 100);
+
+            var destBuffer = memoryStream.GetBuffer();
+
+            RMSAssert.BuffersAreEqual(destBuffer, buffer, 100);            
+        }
+
+        #endregion
+
+        #region CopyToAsync Tests
         [Test]
         public void CopyToAsyncThrowsOnNullDestination()
         {
@@ -3356,7 +3405,7 @@ namespace Microsoft.IO.UnitTests
         public void EventStreamDisposed()
         {
             var mgr = GetMemoryManager();
-            mgr.GenerateCallStacks = true;
+            mgr.options.GenerateCallStacks = true;
             bool raised = false;
             mgr.StreamDisposed += (obj, args) =>
             {
@@ -3378,7 +3427,7 @@ namespace Microsoft.IO.UnitTests
         public void EventStreamDoubleDisposed()
         {
             var mgr = GetMemoryManager();
-            mgr.GenerateCallStacks = true;
+            mgr.options.GenerateCallStacks = true;
             bool raised = false;
             mgr.StreamDoubleDisposed += (obj, args) =>
             {
@@ -3399,7 +3448,7 @@ namespace Microsoft.IO.UnitTests
         public void EventStreamConvertedToArray()
         {
             var mgr = GetMemoryManager();
-            mgr.GenerateCallStacks = true;
+            mgr.options.GenerateCallStacks = true;
             bool raised = false;
             mgr.StreamConvertedToArray += (obj, args) =>
             {
@@ -3419,21 +3468,21 @@ namespace Microsoft.IO.UnitTests
         public void EventStreamOverCapacity()
         {
             var mgr = GetMemoryManager();
-            mgr.MaximumStreamCapacity = mgr.BlockSize;
-            mgr.GenerateCallStacks = true;
+            mgr.options.MaximumStreamCapacity = mgr.options.BlockSize;
+            mgr.options.GenerateCallStacks = true;
             bool raised = false;
             mgr.StreamOverCapacity += (obj, args) =>
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
                 Assert.That(args.Tag, Is.EqualTo("UnitTest"));
                 Assert.That(args.AllocationStack, Contains.Substring("Microsoft.IO.RecyclableMemoryStream..ctor"));
-                Assert.That(args.RequestedCapacity, Is.EqualTo(mgr.BlockSize * 2));
-                Assert.That(args.MaximumCapacity, Is.EqualTo(mgr.BlockSize));
+                Assert.That(args.RequestedCapacity, Is.EqualTo(mgr.options.BlockSize * 2));
+                Assert.That(args.MaximumCapacity, Is.EqualTo(mgr.options.BlockSize));
                 raised = true;
             };
             var stream = mgr.GetStream("UnitTest", 13);
 
-            Assert.Throws<OutOfMemoryException>(()=>stream.Capacity = mgr.BlockSize * 2);
+            Assert.Throws<OutOfMemoryException>(()=>stream.Capacity = mgr.options.BlockSize * 2);
             Assert.That(raised, Is.True);
         }
 
@@ -3444,7 +3493,7 @@ namespace Microsoft.IO.UnitTests
             bool raised = false;
             mgr.BlockCreated += (obj, args) =>
             {
-                Assert.That(args.SmallPoolInUse, Is.EqualTo(mgr.BlockSize));
+                Assert.That(args.SmallPoolInUse, Is.EqualTo(mgr.options.BlockSize));
                 raised = true;
             };
             var stream = mgr.GetStream("UnitTest", 13);
@@ -3456,14 +3505,14 @@ namespace Microsoft.IO.UnitTests
         {
             var mgr = GetMemoryManager();
             bool raised = false;
-            long requestedSize = mgr.LargeBufferMultiple;
+            long requestedSize = mgr.options.LargeBufferMultiple;
             mgr.LargeBufferCreated += (obj, args) =>
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
                 Assert.That(args.Tag, Is.EqualTo("UnitTest"));
                 Assert.That(args.Pooled, Is.True);
                 Assert.That(args.RequiredSize, Is.EqualTo(requestedSize));
-                Assert.That(args.LargePoolInUse, Is.EqualTo(mgr.LargeBufferMultiple));
+                Assert.That(args.LargePoolInUse, Is.EqualTo(mgr.options.LargeBufferMultiple));
                 Assert.That(args.CallStack, Is.Null);
 
                 raised = true;
@@ -3479,9 +3528,9 @@ namespace Microsoft.IO.UnitTests
         public void EventUnpooledLargeBufferCreated()
         {
             var mgr = GetMemoryManager();
-            mgr.GenerateCallStacks = true;
+            mgr.options.GenerateCallStacks = true;
             bool raised = false;
-            long requestedSize = mgr.MaximumBufferSize + 1;
+            long requestedSize = mgr.options.MaximumBufferSize + 1;
             mgr.LargeBufferCreated += (obj, args) =>
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
@@ -3504,9 +3553,9 @@ namespace Microsoft.IO.UnitTests
         public void EventBlockDiscarded()
         {
             var mgr = GetMemoryManager();
-            mgr.MaximumFreeSmallPoolBytes = mgr.BlockSize;
+            mgr.options.MaximumSmallPoolFreeBytes = mgr.options.BlockSize;
             int raisedCount = 0;
-            long requestedSize = mgr.BlockSize;
+            long requestedSize = mgr.options.BlockSize;
             mgr.BufferDiscarded += (obj, args) =>
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
@@ -3530,9 +3579,9 @@ namespace Microsoft.IO.UnitTests
         public void EventLargeBufferDiscardedEnoughFree()
         {
             var mgr = GetMemoryManager();
-            mgr.MaximumFreeLargePoolBytes = mgr.LargeBufferMultiple;
+            mgr.options.MaximumLargePoolFreeBytes = mgr.options.LargeBufferMultiple;
             int raisedCount = 0;
-            long requestedSize = mgr.LargeBufferMultiple;
+            long requestedSize = mgr.options.LargeBufferMultiple;
             mgr.BufferDiscarded += (obj, args) =>
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
@@ -3560,7 +3609,7 @@ namespace Microsoft.IO.UnitTests
             var mgr = GetMemoryManager();
 
             int raisedCount = 0;
-            long requestedSize = mgr.MaximumBufferSize + 1;
+            long requestedSize = mgr.options.MaximumBufferSize + 1;
             mgr.BufferDiscarded += (obj, args) =>
             {
                 Assert.That(args.Id, Is.Not.EqualTo(Guid.Empty));
@@ -3586,11 +3635,11 @@ namespace Microsoft.IO.UnitTests
             var mgr = GetMemoryManager();
 
             int raisedCount = 0;
-            long requestedSize = mgr.BlockSize;
+            long requestedSize = mgr.options.BlockSize;
             mgr.UsageReport += (obj, args) =>
             {
-                Assert.That(args.SmallPoolFreeBytes, Is.EqualTo(raisedCount == 0 ? 0 : mgr.BlockSize));
-                Assert.That(args.SmallPoolInUseBytes, Is.EqualTo(raisedCount == 0 ? mgr.BlockSize : 0));
+                Assert.That(args.SmallPoolFreeBytes, Is.EqualTo(raisedCount == 0 ? 0 : mgr.options.BlockSize));
+                Assert.That(args.SmallPoolInUseBytes, Is.EqualTo(raisedCount == 0 ? mgr.options.BlockSize : 0));
                 Assert.That(args.LargePoolFreeBytes, Is.EqualTo(0));
                 Assert.That(args.LargePoolInUseBytes, Is.EqualTo(0));
 
@@ -3623,12 +3672,15 @@ namespace Microsoft.IO.UnitTests
 
         protected virtual RecyclableMemoryStreamManager GetMemoryManager()
         {
-            return new RecyclableMemoryStreamManager(DefaultBlockSize, DefaultLargeBufferMultiple,
-                                                     DefaultMaximumBufferSize, this.UseExponentialLargeBuffer)
-                   {
-                       AggressiveBufferReturn = this.AggressiveBufferRelease,
-                       ZeroOutBuffer = this.ZeroOutBuffer,
-                   };
+            return new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options
+            {
+                BlockSize = DefaultBlockSize,
+                LargeBufferMultiple = DefaultLargeBufferMultiple,
+                MaximumBufferSize = DefaultMaximumBufferSize,
+                UseExponentialLargeBuffer = this.UseExponentialLargeBuffer,
+                AggressiveBufferReturn = this.AggressiveBufferRelease,
+                ZeroOutBuffer = this.ZeroOutBuffer,
+            });
         }
 
         private RecyclableMemoryStream GetRandomStream()
@@ -3650,8 +3702,14 @@ namespace Microsoft.IO.UnitTests
             long maximumFreeLargePoolBytes = UInt32.MaxValue;
             int blockSize = 128000;
 
-            var mgr = new RecyclableMemoryStreamManager(blockSize, 1<<20, 8 * (1<<20),
-                                              maximumFreeSmallPoolBytes, maximumFreeLargePoolBytes);
+            var mgr = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options
+            {
+                BlockSize = blockSize,
+                LargeBufferMultiple = 1 << 20,
+                MaximumBufferSize = 8 * (1 << 20),
+                MaximumSmallPoolFreeBytes = maximumFreeSmallPoolBytes,
+                 MaximumLargePoolFreeBytes = maximumFreeLargePoolBytes
+            });
 
             MemoryStream fillStream = mgr.GetStream("pool", requiredSize: 128000, asContiguousBuffer: true);
             byte[] block1 = new byte[128000];
@@ -3675,7 +3733,7 @@ namespace Microsoft.IO.UnitTests
         [Test]
         public void BlockZeroedBeforeReturn() {
             var memMgr = this.GetMemoryManager();
-            memMgr.ReturnBlock(this.GetRandomBuffer(memMgr.BlockSize), DefaultId, DefaultTag);
+            memMgr.ReturnBlock(this.GetRandomBuffer(memMgr.options.BlockSize), DefaultId, DefaultTag);
             Assert.That(memMgr.SmallBlocksFree, Is.EqualTo(1));
             var block = memMgr.GetBlock();
             Assert.That(block, this.ZeroOutBuffer ? Is.All.EqualTo(0) : Is.Not.All.EqualTo(0));
@@ -3687,7 +3745,7 @@ namespace Microsoft.IO.UnitTests
             var memMgr = this.GetMemoryManager();
             var blocks = new List<byte[]>(numBlocks);
             for (var blockId = 0; blockId < numBlocks; ++blockId) {
-                blocks.Add(this.GetRandomBuffer(memMgr.BlockSize));
+                blocks.Add(this.GetRandomBuffer(memMgr.options.BlockSize));
             }
             memMgr.ReturnBlocks(blocks, DefaultId, DefaultTag);
             Assert.That(memMgr.SmallBlocksFree, Is.EqualTo(blocks.Count));
@@ -3700,9 +3758,9 @@ namespace Microsoft.IO.UnitTests
         [Test]
         public void LargeBufferZeroedBeforeReturn() {
             var memMgr = this.GetMemoryManager();
-            memMgr.ReturnLargeBuffer(this.GetRandomBuffer(memMgr.LargeBufferMultiple), DefaultId, DefaultTag);
+            memMgr.ReturnLargeBuffer(this.GetRandomBuffer(memMgr.options.LargeBufferMultiple), DefaultId, DefaultTag);
             Assert.That(memMgr.LargeBuffersFree, Is.EqualTo(1));
-            var buffer = memMgr.GetLargeBuffer(memMgr.LargeBufferMultiple, DefaultId, DefaultTag);
+            var buffer = memMgr.GetLargeBuffer(memMgr.options.LargeBufferMultiple, DefaultId, DefaultTag);
             Assert.That(buffer, this.ZeroOutBuffer ? Is.All.EqualTo(0) : Is.Not.All.EqualTo(0));
         }
 
@@ -3816,34 +3874,34 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var memMgr = stream.MemoryManager;
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             stream.GetBuffer();
 
-            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1)));
+            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1)));
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1 + 2)));
+            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2)));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1 + 2 + 3)));
+            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 3)));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
 
             stream.Dispose();
 
-            Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1 + 2 + 3)));
+            Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 3)));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
     }
@@ -3868,18 +3926,17 @@ namespace Microsoft.IO.UnitTests
         public override void RecyclableMemoryManagerUsingMultipleOrExponentialLargeBuffer()
         {
             var memMgr = this.GetMemoryManager();
-            Assert.That(memMgr.UseMultipleLargeBuffer, Is.False);
-            Assert.That(memMgr.UseExponentialLargeBuffer, Is.True);
+            Assert.That(memMgr.options.UseExponentialLargeBuffer, Is.True);
         }
 
         [Test]
         public override void RecyclableMemoryManagerThrowsExceptionOnMaximumBufferNotMultipleOrExponentialOfLargeBufferMultiple()
         {
-            Assert.Throws<ArgumentException>(() => new RecyclableMemoryStreamManager(100, 1024, 2025, this.UseExponentialLargeBuffer));
-            Assert.Throws<ArgumentException>(() => new RecyclableMemoryStreamManager(100, 1024, 2023, this.UseExponentialLargeBuffer));
-            Assert.Throws<ArgumentException>(() => new RecyclableMemoryStreamManager(100, 1024, 3072, this.UseExponentialLargeBuffer));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(100, 1024, 2048, this.UseExponentialLargeBuffer));
-            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(100, 1024, 4096, this.UseExponentialLargeBuffer));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 2025, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 2023, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 3072, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 2048, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
+            Assert.DoesNotThrow(() => new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options { BlockSize = 100, LargeBufferMultiple = 1024, MaximumBufferSize = 4096, UseExponentialLargeBuffer = this.UseExponentialLargeBuffer }));
         }
 
         [Test]
@@ -3894,8 +3951,8 @@ namespace Microsoft.IO.UnitTests
             {
                 var buffer = memMgr.GetLargeBuffer(i, DefaultId, DefaultTag);
                 Assert.That(buffer.Length >= i, Is.True);
-                Assert.That(memMgr.LargeBufferMultiple * (int)Math.Pow(2, Math.Floor(Math.Log(buffer.Length / memMgr.LargeBufferMultiple, 2))) == buffer.Length, Is.True,
-                            "buffer length of {0} is not a exponential of {1}", buffer.Length, memMgr.LargeBufferMultiple);
+                Assert.That(memMgr.options.LargeBufferMultiple * (int)Math.Pow(2, Math.Floor(Math.Log(buffer.Length / memMgr.options.LargeBufferMultiple, 2))) == buffer.Length, Is.True,
+                            "buffer length of {0} is not a exponential of {1}", buffer.Length, memMgr.options.LargeBufferMultiple);
             }
         }
 
@@ -3908,8 +3965,15 @@ namespace Microsoft.IO.UnitTests
 
             for (var size = LargeBufferMultiple; size <= MaxBufferSize; size *= 2)
             {
-                var memMgr = new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize, this.UseExponentialLargeBuffer)
-                             { AggressiveBufferReturn = this.AggressiveBufferRelease };
+                var memMgr = new RecyclableMemoryStreamManager(
+                    new RecyclableMemoryStreamManager.Options {
+                        BlockSize = BlockSize,
+                        LargeBufferMultiple = LargeBufferMultiple,
+                        MaximumBufferSize = MaxBufferSize,
+                        UseExponentialLargeBuffer = this.UseExponentialLargeBuffer,
+                        AggressiveBufferReturn = this.AggressiveBufferRelease
+                    });
+                             
                 var buffer = memMgr.GetLargeBuffer(size, DefaultId, DefaultTag);
                 Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
                 Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(size));
@@ -3931,15 +3995,23 @@ namespace Microsoft.IO.UnitTests
             const int LargeBufferMultiple = 1024;
             const int MaxBufferSize = int.MaxValue;
 
-            Assert.Throws<ArgumentException>(()=>new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize, this.UseExponentialLargeBuffer) { AggressiveBufferReturn = this.AggressiveBufferRelease });
+            Assert.Throws<InvalidOperationException>(() => new RecyclableMemoryStreamManager(
+                new RecyclableMemoryStreamManager.Options
+                {
+                    BlockSize = BlockSize,
+                    LargeBufferMultiple = LargeBufferMultiple,
+                    MaximumBufferSize = MaxBufferSize,
+                    UseExponentialLargeBuffer = this.UseExponentialLargeBuffer,
+                    AggressiveBufferReturn = this.AggressiveBufferRelease
+                }));
         }
 
         [Test]
         public override void RequestTooLargeBufferAdjustsInUseCounter()
         {
             var memMgr = this.GetMemoryManager();
-            var buffer = memMgr.GetLargeBuffer(memMgr.MaximumBufferSize + 1, DefaultId, DefaultTag);
-            Assert.That(buffer.Length, Is.EqualTo(memMgr.MaximumBufferSize * 2));
+            var buffer = memMgr.GetLargeBuffer(memMgr.options.MaximumBufferSize + 1, DefaultId, DefaultTag);
+            Assert.That(buffer.Length, Is.EqualTo(memMgr.options.MaximumBufferSize * 2));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(buffer.Length));
         }
 
@@ -3951,11 +4023,15 @@ namespace Microsoft.IO.UnitTests
 
             for (var size = LargeBufferMultiple; size <= MaxBufferSize; size *= 2)
             {
-                var memMgr = new RecyclableMemoryStreamManager(BlockSize, LargeBufferMultiple, MaxBufferSize, this.UseExponentialLargeBuffer)
-                             {
-                                 AggressiveBufferReturn = this.AggressiveBufferRelease,
-                                 MaximumFreeLargePoolBytes = maxFreeLargeBufferSize
-                             };
+                var memMgr = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options
+                {
+                    BlockSize = BlockSize,
+                    LargeBufferMultiple = LargeBufferMultiple,
+                    MaximumBufferSize = MaxBufferSize,
+                    UseExponentialLargeBuffer = this.UseExponentialLargeBuffer,
+                    AggressiveBufferReturn = this.AggressiveBufferRelease,
+                    MaximumLargePoolFreeBytes = maxFreeLargeBufferSize
+                });
 
                 var buffers = new List<byte[]>();
 
@@ -3997,34 +4073,34 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var memMgr = stream.MemoryManager;
-            var buffer = this.GetRandomBuffer(stream.MemoryManager.LargeBufferMultiple);
+            var buffer = this.GetRandomBuffer(stream.MemoryManager.options.LargeBufferMultiple);
             stream.Write(buffer, 0, buffer.Length);
             stream.GetBuffer();
 
-            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1)));
+            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1)));
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1 + 2)));
+            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2)));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1 + 2 + 4)));
+            Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 4)));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
 
             stream.Dispose();
 
-            Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(memMgr.LargeBufferMultiple * (1 + 2 + 4)));
+            Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 4)));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(0));
-            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.LargeBufferMultiple));
+            Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
         }
     }

--- a/src/EventArgs.cs
+++ b/src/EventArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.IO
+namespace Microsoft.IO
 {
     using System;
 
@@ -315,8 +315,8 @@
             public long LargePoolInUse { get; }
 
             /// <summary>
-            /// If the buffer was not satisfied from the pool, and <see cref="GenerateCallStacks"/> is turned on, then.
-            /// this will contain the callstack of the allocation request.
+            /// If the buffer was not satisfied from the pool, and <see cref="Options.GenerateCallStacks"/> is turned on, then.
+            /// this will contain the call stack of the allocation request.
             /// </summary>
             public string? CallStack { get; }
 
@@ -328,7 +328,7 @@
             /// <param name="requiredSize">Required size of the new buffer.</param>
             /// <param name="largePoolInUse">How many bytes from the large pool are currently in use.</param>
             /// <param name="pooled">Whether the buffer was satisfied from the pool or not.</param>
-            /// <param name="callStack">Callstack of the allocation, if it wasn't pooled.</param>
+            /// <param name="callStack">Call stack of the allocation, if it wasn't pooled.</param>
             internal LargeBufferCreatedEventArgs(Guid guid, string? tag, long requiredSize, long largePoolInUse, bool pooled, string? callStack)
             {
                 this.RequiredSize = requiredSize;

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -155,7 +155,7 @@ namespace Microsoft.IO
         /// <summary>
         /// Parameters for customizing the behavior of <see cref="RecyclableMemoryStreamManager"/>
         /// </summary>
-        public struct Options
+        public class Options
         {
             /// <summary>
             /// Gets or sets the size of the pooled blocks. This must be greater than 0.

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -80,7 +80,7 @@ namespace Microsoft.IO
         private long smallPoolFreeSize;
         private long smallPoolInUseSize;
 
-        internal Options options;
+        internal readonly Options options;
 
         /// <summary>
         /// Settings for controlling the behavior of RecyclableMemoryStream

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -25,7 +25,6 @@ namespace Microsoft.IO
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.IO;
     using System.Runtime.CompilerServices;
     using System.Threading;
 
@@ -39,7 +38,7 @@ namespace Microsoft.IO
     ///</para>
     ///<para>
     /// For scenarios that need to call <see cref="RecyclableMemoryStream.GetBuffer"/>, the large pool contains buffers of various sizes, all
-    /// multiples/exponentials of <see cref="LargeBufferMultiple"/> (1 MB by default). They are split by size to avoid overly-wasteful buffer
+    /// multiples/exponentials of <see cref="Options.LargeBufferMultiple"/> (1 MB by default). They are split by size to avoid overly-wasteful buffer
     /// usage. There should be far fewer 8 MB buffers than 1 MB buffers, for example.
     /// </para>
     /// </remarks>
@@ -81,177 +80,12 @@ namespace Microsoft.IO
         private long smallPoolFreeSize;
         private long smallPoolInUseSize;
 
-        /// <summary>
-        /// Initializes the memory manager with the default block/buffer specifications. This pool may have unbounded growth unless you modify <see cref="MaximumFreeSmallPoolBytes"/> and <see cref="MaximumFreeLargePoolBytes"/>.
-        /// </summary>
-        public RecyclableMemoryStreamManager()
-            : this(DefaultBlockSize, DefaultLargeBufferMultiple, DefaultMaximumBufferSize, false, DefaultMaxSmallPoolFreeBytes, DefaultMaxLargePoolFreeBytes) { }
+        internal Options options;
 
         /// <summary>
-        /// Initializes the memory manager with the default block/buffer specifications and maximum free bytes specifications.
+        /// Settings for controlling the behavior of RecyclableMemoryStream
         /// </summary>
-        /// <param name="maximumSmallPoolFreeBytes">Maximum number of bytes to keep available in the small pool before future buffers get dropped for garbage collection</param>
-        /// <param name="maximumLargePoolFreeBytes">Maximum number of bytes to keep available in the large pool before future buffers get dropped for garbage collection</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumSmallPoolFreeBytes"/> is negative, or <paramref name="maximumLargePoolFreeBytes"/> is negative.</exception>
-        public RecyclableMemoryStreamManager(long maximumSmallPoolFreeBytes, long maximumLargePoolFreeBytes)
-            :this(DefaultBlockSize, DefaultLargeBufferMultiple, DefaultMaximumBufferSize, useExponentialLargeBuffer:false, maximumSmallPoolFreeBytes, maximumLargePoolFreeBytes)
-        {
-        }
-
-        /// <summary>
-        /// Initializes the memory manager with the given block requiredSize. This pool may have unbounded growth unless you modify <see cref="MaximumFreeSmallPoolBytes"/> and <see cref="MaximumFreeLargePoolBytes"/>.
-        /// </summary>
-        /// <param name="blockSize">Size of each block that is pooled. Must be > 0.</param>
-        /// <param name="largeBufferMultiple">Each large buffer will be a multiple of this value.</param>
-        /// <param name="maximumBufferSize">Buffers larger than this are not pooled</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="blockSize"/> is not a positive number,
-        /// or <paramref name="largeBufferMultiple"/> is not a positive number,
-        /// or <paramref name="maximumBufferSize"/> is less than <paramref name="blockSize"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="maximumBufferSize"/> is not a multiple of <paramref name="largeBufferMultiple"/>.</exception>
-        public RecyclableMemoryStreamManager(int blockSize, int largeBufferMultiple, int maximumBufferSize)
-            : this(blockSize, largeBufferMultiple, maximumBufferSize, false, DefaultMaxSmallPoolFreeBytes, DefaultMaxLargePoolFreeBytes) { }
-
-        /// <summary>
-        /// Initializes the memory manager with the given block requiredSize.
-        /// </summary>
-        /// <param name="blockSize">Size of each block that is pooled. Must be > 0.</param>
-        /// <param name="largeBufferMultiple">Each large buffer will be a multiple of this value.</param>
-        /// <param name="maximumBufferSize">Buffers larger than this are not pooled</param>
-        /// <param name="maximumSmallPoolFreeBytes">Maximum number of bytes to keep available in the small pool before future buffers get dropped for garbage collection</param>
-        /// <param name="maximumLargePoolFreeBytes">Maximum number of bytes to keep available in the large pool before future buffers get dropped for garbage collection</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="blockSize"/> is not a positive number,
-        /// or <paramref name="largeBufferMultiple"/> is not a positive number,
-        /// or <paramref name="maximumBufferSize"/> is less than <paramref name="blockSize"/>,
-        /// or <paramref name="maximumSmallPoolFreeBytes"/> is negative,
-        /// or <paramref name="maximumLargePoolFreeBytes"/> is negative.
-        /// </exception>
-        /// <exception cref="ArgumentException"><paramref name="maximumBufferSize"/> is not a multiple of <paramref name="largeBufferMultiple"/>.</exception>
-        public RecyclableMemoryStreamManager(int blockSize, int largeBufferMultiple, int maximumBufferSize, long maximumSmallPoolFreeBytes, long maximumLargePoolFreeBytes)
-            : this(blockSize, largeBufferMultiple, maximumBufferSize, false, maximumSmallPoolFreeBytes, maximumLargePoolFreeBytes) { }
-
-
-        /// <summary>
-        /// Initializes the memory manager with the given block requiredSize. This pool may have unbounded growth unless you modify <see cref="MaximumFreeSmallPoolBytes"/> and <see cref="MaximumFreeLargePoolBytes"/>.
-        /// </summary>
-        /// <param name="blockSize">Size of each block that is pooled. Must be > 0.</param>
-        /// <param name="largeBufferMultiple">Each large buffer will be a multiple/exponential of this value.</param>
-        /// <param name="maximumBufferSize">Buffers larger than this are not pooled</param>
-        /// <param name="useExponentialLargeBuffer">Switch to exponential large buffer allocation strategy</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="blockSize"/> is not a positive number,
-        /// or <paramref name="largeBufferMultiple"/> is not a positive number,
-        /// or <paramref name="maximumBufferSize"/> is less than <paramref name="blockSize"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="maximumBufferSize"/> is not a multiple/exponential of <paramref name="largeBufferMultiple"/>.</exception>
-        public RecyclableMemoryStreamManager(int blockSize, int largeBufferMultiple, int maximumBufferSize, bool useExponentialLargeBuffer)
-            :this(blockSize, largeBufferMultiple, maximumBufferSize, useExponentialLargeBuffer, DefaultMaxSmallPoolFreeBytes, DefaultMaxLargePoolFreeBytes)
-        {
-        }
-
-        /// <summary>
-        /// Initializes the memory manager with the given block requiredSize.
-        /// </summary>
-        /// <param name="blockSize">Size of each block that is pooled. Must be > 0.</param>
-        /// <param name="largeBufferMultiple">Each large buffer will be a multiple/exponential of this value.</param>
-        /// <param name="maximumBufferSize">Buffers larger than this are not pooled.</param>
-        /// <param name="useExponentialLargeBuffer">Switch to exponential large buffer allocation strategy.</param>
-        /// <param name="maximumSmallPoolFreeBytes">Maximum number of bytes to keep available in the small pool before future buffers get dropped for garbage collection.</param>
-        /// <param name="maximumLargePoolFreeBytes">Maximum number of bytes to keep available in the large pool before future buffers get dropped for garbage collection.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="blockSize"/> is not a positive number,
-        /// or <paramref name="largeBufferMultiple"/> is not a positive number,
-        /// or <paramref name="maximumBufferSize"/> is less than <paramref name="blockSize"/>,
-        /// or <paramref name="maximumSmallPoolFreeBytes"/> is negative,
-        /// or <paramref name="maximumLargePoolFreeBytes"/> is negative.
-        /// </exception>
-        /// <exception cref="ArgumentException"><paramref name="maximumBufferSize"/> is not a multiple/exponential of <paramref name="largeBufferMultiple"/>.</exception>
-        public RecyclableMemoryStreamManager(int blockSize, int largeBufferMultiple, int maximumBufferSize, bool useExponentialLargeBuffer, long maximumSmallPoolFreeBytes, long maximumLargePoolFreeBytes)
-        {
-            if (blockSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(blockSize), blockSize, $"{nameof(blockSize)} must be a positive number");
-            }
-
-            if (largeBufferMultiple <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(largeBufferMultiple), $"{nameof(largeBufferMultiple)} must be a positive number");
-            }
-
-            if (maximumBufferSize < blockSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumBufferSize), $"{nameof(maximumBufferSize)} must be at least {nameof(blockSize)}");
-            }
-
-            if (maximumSmallPoolFreeBytes < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumSmallPoolFreeBytes), $"{nameof(maximumSmallPoolFreeBytes)} must be non-negative");
-            }
-
-            if (maximumLargePoolFreeBytes < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumLargePoolFreeBytes), $"{nameof(maximumLargePoolFreeBytes)} must be non-negative");
-            }
-
-            this.BlockSize = blockSize;
-            this.LargeBufferMultiple = largeBufferMultiple;
-            this.MaximumBufferSize = maximumBufferSize;
-            this.UseExponentialLargeBuffer = useExponentialLargeBuffer;
-            this.MaximumFreeSmallPoolBytes = maximumSmallPoolFreeBytes;
-            this.MaximumFreeLargePoolBytes = maximumLargePoolFreeBytes;
-
-            if (!this.IsLargeBufferSize(maximumBufferSize))
-            {
-                throw new ArgumentException(
-                    $"{nameof(maximumBufferSize)} is not {(this.UseExponentialLargeBuffer ? "an exponential" : "a multiple")} of {nameof(largeBufferMultiple)}.",
-                    nameof(maximumBufferSize));
-            }
-
-            this.smallPool = new ConcurrentStack<byte[]>();
-            var numLargePools = useExponentialLargeBuffer
-                                    ? ((int)Math.Log(maximumBufferSize / largeBufferMultiple, 2) + 1)
-                                    : (maximumBufferSize / largeBufferMultiple);
-
-            // +1 to store size of bytes in use that are too large to be pooled
-            this.largeBufferInUseSize = new long[numLargePools + 1];
-            this.largeBufferFreeSize = new long[numLargePools];
-
-            this.largePools = new ConcurrentStack<byte[]>[numLargePools];
-
-            for (var i = 0; i < this.largePools.Length; ++i)
-            {
-                this.largePools[i] = new ConcurrentStack<byte[]>();
-            }
-
-            Events.Writer.MemoryStreamManagerInitialized(blockSize, largeBufferMultiple, maximumBufferSize);
-        }
-
-        /// <summary>
-        /// The size of each block. It must be set at creation and cannot be changed.
-        /// </summary>
-        public int BlockSize { get; }
-
-        /// <summary>
-        /// All buffers are multiples/exponentials of this number. It must be set at creation and cannot be changed.
-        /// </summary>
-        public int LargeBufferMultiple { get; }
-
-        /// <summary>
-        /// Use multiple large buffer allocation strategy. It must be set at creation and cannot be changed.
-        /// </summary>
-        public bool UseMultipleLargeBuffer => !this.UseExponentialLargeBuffer;
-
-        /// <summary>
-        /// Use exponential large buffer allocation strategy. It must be set at creation and cannot be changed.
-        /// </summary>
-        public bool UseExponentialLargeBuffer { get; }
-
-        /// <summary>
-        /// Gets the maximum buffer size.
-        /// </summary>
-        /// <remarks>Any buffer that is returned to the pool that is larger than this will be
-        /// discarded and garbage collected.</remarks>
-        public int MaximumBufferSize { get; }
+        public Options Settings { get { return this.options; } }
 
         /// <summary>
         /// Number of bytes in small pool not currently in use.
@@ -319,60 +153,192 @@ namespace Microsoft.IO
         }
 
         /// <summary>
-        /// How many bytes of small free blocks to allow before we start dropping
-        /// those returned to us.
+        /// Parameters for customizing the behavior of <see cref="RecyclableMemoryStreamManager"/>
         /// </summary>
-        /// <remarks>The default value is 0, meaning the pool is unbounded.</remarks>
-        public long MaximumFreeSmallPoolBytes { get; set; }
+        public struct Options
+        {
+            /// <summary>
+            /// Gets or sets the size of the pooled blocks. This must be greater than 0.
+            /// </summary>
+            /// <remarks>The default size 131,072 (128KB)</remarks>
+            public int BlockSize { get; set; } = DefaultBlockSize;
+
+            /// <summary>
+            /// Each large buffer will be a multiple exponential of this value
+            /// </summary>
+            /// <remarks>The default value is 1,048,576 (1MB)</remarks>
+            public int LargeBufferMultiple { get; set; } = DefaultLargeBufferMultiple;
+
+            /// <summary>
+            /// Buffer beyond this length are not pooled.
+            /// </summary>
+            /// <remarks>The default value is 134,217,728 (128MB)</remarks>
+            public int MaximumBufferSize { get; set; } = DefaultMaximumBufferSize;
+
+            /// <summary>
+            /// Maximum number of bytes to keep available in the small pool.
+            /// </summary>
+            /// <remarks>
+            /// <para>Trying to return buffers to the pool beyond this limit will result in them being garbage collected.</para>
+            /// <para>The default value is 0, but all users should set a reasonable value depending on your application's memory requirements.</para>
+            /// </remarks>
+            public long MaximumSmallPoolFreeBytes { get; set; }
+
+            /// <summary>
+            /// Maximum number of bytes to keep available in the large pools.
+            /// </summary>
+            /// <remarks>
+            /// <para>Trying to return buffers to the pool beyond this limit will result in them being garbage collected.</para>
+            /// <para>The default value is 0, but all users should set a reasonable value depending on your application's memory requirements.</para>
+            /// </remarks>
+            public long MaximumLargePoolFreeBytes { get; set; }
+
+            /// <summary>
+            /// Whether to use the exponential allocation strategy (see documentation).
+            /// </summary>
+            /// <remarks>The default value is false.</remarks>
+            public bool UseExponentialLargeBuffer { get; set; } = false;
+
+            /// <summary>
+            /// Maximum stream capacity in bytes. Attempts to set a larger capacity will
+            /// result in an exception.
+            /// </summary>
+            /// <remarks>The default value of 0 indicates no limit.</remarks>
+            public long MaximumStreamCapacity { get; set; } = 0;
+
+            /// <summary>
+            /// Whether to save call stacks for stream allocations. This can help in debugging.
+            /// It should NEVER be turned on generally in production.
+            /// </summary>
+            public bool GenerateCallStacks { get; set; } = false;
+
+            /// <summary>
+            /// Whether dirty buffers can be immediately returned to the buffer pool.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// When <see cref="RecyclableMemoryStream.GetBuffer"/> is called on a stream and creates a single large buffer, if this setting is enabled, the other blocks will be returned
+            /// to the buffer pool immediately.
+            /// </para>
+            /// <para>
+            /// Note when enabling this setting that the user is responsible for ensuring that any buffer previously
+            /// retrieved from a stream which is subsequently modified is not used after modification (as it may no longer
+            /// be valid).
+            /// </para>
+            /// </remarks>
+            public bool AggressiveBufferReturn { get; set; } = false;
+
+            /// <summary>
+            /// Causes an exception to be thrown if <see cref="RecyclableMemoryStream.ToArray"/> is ever called.
+            /// </summary>
+            /// <remarks>Calling <see cref="RecyclableMemoryStream.ToArray"/> defeats the purpose of a pooled buffer. Use this property to discover code that is calling <see cref="RecyclableMemoryStream.ToArray"/>. If this is
+            /// set and <see cref="RecyclableMemoryStream.ToArray"/> is called, a <c>NotSupportedException</c> will be thrown.</remarks>
+            public bool ThrowExceptionOnToArray { get; set; } = false;
+
+            /// <summary>
+            /// Zero out buffers on allocation and before returning them to the pool.
+            /// </summary>
+            /// <remarks>Setting this to true causes a performance hit and should only be set if one wants to avoid accidental data leaks.</remarks>
+            public bool ZeroOutBuffer { get; set; } = false;
+
+            /// <summary>
+            /// Creates a new <see cref="Options"/> object.
+            /// </summary>
+            public Options()
+            {
+                
+            }
+
+            /// <summary>
+            /// Creates a new <see cref="Options"/> object with the most common options.
+            /// </summary>
+            /// <param name="blockSize">Size of the blocks in the small pool.</param>
+            /// <param name="largeBufferMultiple">Size of the large buffer multiple</param>
+            /// <param name="maximumBufferSize">Maximum poolable buffer size.</param>
+            /// <param name="maximumSmallPoolFreeBytes">Maximum bytes to hold in the small pool.</param>
+            /// <param name="maximumLargePoolFreeBytes">Maximum bytes to hold in each of the large pools.</param>
+            public Options(int blockSize, int largeBufferMultiple, int maximumBufferSize, long maximumSmallPoolFreeBytes, long maximumLargePoolFreeBytes)
+            {
+                this.BlockSize = blockSize;
+                this.LargeBufferMultiple = largeBufferMultiple;
+                this.MaximumBufferSize = maximumBufferSize;
+                this.MaximumSmallPoolFreeBytes = maximumSmallPoolFreeBytes;
+                this.MaximumLargePoolFreeBytes = maximumLargePoolFreeBytes;
+            }
+        }
 
         /// <summary>
-        /// How many bytes of large free buffers to allow before we start dropping
-        /// those returned to us.
+        /// Initializes the memory manager with the default block/buffer specifications. This pool may have unbounded growth unless you modify <see cref="Options"/>.
         /// </summary>
-        /// <remarks>The default value is 0, meaning the pool is unbounded.</remarks>
-        public long MaximumFreeLargePoolBytes { get; set; }
+        public RecyclableMemoryStreamManager()
+            : this(new Options()) { }
+
 
         /// <summary>
-        /// Maximum stream capacity in bytes. Attempts to set a larger capacity will
-        /// result in an exception.
+        /// Initializes the memory manager with the given block requiredSize.
         /// </summary>
-        /// <remarks>A value of 0 indicates no limit.</remarks>
-        public long MaximumStreamCapacity { get; set; }
+        /// <param name="options">Object specifying options for stream behavior.</param>
+        /// <exception cref="InvalidOperationException">
+        /// <paramref name="options.BlockSize"/> is not a positive number,
+        /// or <paramref name="options.LargeBufferMultiple"/> is not a positive number,
+        /// or <paramref name="options.MaximumBufferSize"/> is less than options.BlockSize,
+        /// or <paramref name="options.MaximumSmallPoolFreeBytes"/> is negative,
+        /// or <paramref name="options.MaximumLargePoolFreeBytes"/> is negative,
+        /// or <paramref name="options.MaximumBufferSize"/> is not a multiple/exponential of <paramref name="options.LargeBufferMultiple"/>.
+        /// </exception>
+        public RecyclableMemoryStreamManager(Options options)
+        {
+            if (options.BlockSize <= 0)
+            {
+                throw new InvalidOperationException($"{nameof(options.BlockSize)} must be a positive number");
+            }
 
-        /// <summary>
-        /// Whether to save callstacks for stream allocations. This can help in debugging.
-        /// It should NEVER be turned on generally in production.
-        /// </summary>
-        public bool GenerateCallStacks { get; set; }
+            if (options.LargeBufferMultiple <= 0)
+            {
+                throw new InvalidOperationException($"{nameof(options.LargeBufferMultiple)} must be a positive number");
+            }
 
-        /// <summary>
-        /// Whether dirty buffers can be immediately returned to the buffer pool.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// When <see cref="RecyclableMemoryStream.GetBuffer"/> is called on a stream and creates a single large buffer, if this setting is enabled, the other blocks will be returned
-        /// to the buffer pool immediately.
-        /// </para>
-        /// <para>
-        /// Note when enabling this setting that the user is responsible for ensuring that any buffer previously
-        /// retrieved from a stream which is subsequently modified is not used after modification (as it may no longer
-        /// be valid).
-        /// </para>
-        /// </remarks>
-        public bool AggressiveBufferReturn { get; set; }
+            if (options.MaximumBufferSize < options.BlockSize)
+            {
+                throw new InvalidOperationException($"{nameof(options.MaximumBufferSize)} must be at least {nameof(options.BlockSize)}");
+            }
 
-        /// <summary>
-        /// Causes an exception to be thrown if <see cref="RecyclableMemoryStream.ToArray"/> is ever called.
-        /// </summary>
-        /// <remarks>Calling <see cref="RecyclableMemoryStream.ToArray"/> defeats the purpose of a pooled buffer. Use this property to discover code that is calling <see cref="RecyclableMemoryStream.ToArray"/>. If this is
-        /// set and <see cref="RecyclableMemoryStream.ToArray"/> is called, a <c>NotSupportedException</c> will be thrown.</remarks>
-        public bool ThrowExceptionOnToArray { get; set; }
+            if (options.MaximumSmallPoolFreeBytes < 0)
+            {
+                throw new InvalidOperationException($"{nameof(options.MaximumSmallPoolFreeBytes)} must be non-negative");
+            }
 
-        /// <summary>
-        /// Zero out buffers on allocation and before returning them to the pool.
-        /// </summary>
-        /// <remarks>Setting this to true causes a performance hit and should only be set if one wants to avoid accidental data leaks.</remarks>
-        public bool ZeroOutBuffer { get; set; }
+            if (options.MaximumLargePoolFreeBytes < 0)
+            {
+                throw new InvalidOperationException($"{nameof(options.MaximumLargePoolFreeBytes)} must be non-negative");
+            }
+
+            this.options = options;
+
+            if (!this.IsLargeBufferSize(options.MaximumBufferSize))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(options.MaximumBufferSize)} is not {(options.UseExponentialLargeBuffer ? "an exponential" : "a multiple")} of {nameof(options.LargeBufferMultiple)}.");
+            }
+
+            this.smallPool = new ConcurrentStack<byte[]>();
+            var numLargePools = options.UseExponentialLargeBuffer
+                                    ? ((int)Math.Log(options.MaximumBufferSize / options.LargeBufferMultiple, 2) + 1)
+                                    : (options.MaximumBufferSize / options.LargeBufferMultiple);
+
+            // +1 to store size of bytes in use that are too large to be pooled
+            this.largeBufferInUseSize = new long[numLargePools + 1];
+            this.largeBufferFreeSize = new long[numLargePools];
+
+            this.largePools = new ConcurrentStack<byte[]>[numLargePools];
+
+            for (var i = 0; i < this.largePools.Length; ++i)
+            {
+                this.largePools[i] = new ConcurrentStack<byte[]>();
+            }
+
+            Events.Writer.MemoryStreamManagerInitialized(options.BlockSize, options.LargeBufferMultiple, options.MaximumBufferSize);
+        }
 
         /// <summary>
         /// Removes and returns a single block from the pool.
@@ -380,22 +346,22 @@ namespace Microsoft.IO
         /// <returns>A <c>byte[]</c> array.</returns>
         internal byte[] GetBlock()
         {
-            Interlocked.Add(ref this.smallPoolInUseSize, this.BlockSize);
+            Interlocked.Add(ref this.smallPoolInUseSize, this.options.BlockSize);
 
             if (!this.smallPool.TryPop(out byte[]? block))
             {
                 // We'll add this back to the pool when the stream is disposed
                 // (unless our free pool is too large)
 #if NET6_0_OR_GREATER
-                block = this.ZeroOutBuffer ? GC.AllocateArray<byte>(BlockSize) : GC.AllocateUninitializedArray<byte>(this.BlockSize);
+                block = this.options.ZeroOutBuffer ? GC.AllocateArray<byte>(this.options.BlockSize) : GC.AllocateUninitializedArray<byte>(this.options.BlockSize);
 #else
-                block = new byte[this.BlockSize];
+                block = new byte[this.options.BlockSize];
 #endif
                 ReportBlockCreated();
             }
             else
             {
-                Interlocked.Add(ref this.smallPoolFreeSize, -this.BlockSize);
+                Interlocked.Add(ref this.smallPoolFreeSize, -this.options.BlockSize);
             }
 
             return block;
@@ -430,7 +396,7 @@ namespace Microsoft.IO
             {
                 if (!this.largePools[poolIndex].TryPop(out buffer))
                 {
-                    buffer = AllocateArray(requiredSize, this.ZeroOutBuffer);
+                    buffer = AllocateArray(requiredSize, this.options.ZeroOutBuffer);
                     createdNew = true;
                 }
                 else
@@ -447,8 +413,8 @@ namespace Microsoft.IO
                 poolIndex = this.largeBufferInUseSize.Length - 1;
 
                 // We still want to round up to reduce heap fragmentation.
-                buffer = AllocateArray(requiredSize, this.ZeroOutBuffer);
-                if (this.GenerateCallStacks)
+                buffer = AllocateArray(requiredSize, this.options.ZeroOutBuffer);
+                if (this.options.GenerateCallStacks)
                 {
                     // Grab the stack -- we want to know who requires such large buffers
                     callStack = Environment.StackTrace;
@@ -476,34 +442,34 @@ namespace Microsoft.IO
 
         private long RoundToLargeBufferSize(long requiredSize)
         {
-            if (this.UseExponentialLargeBuffer)
+            if (this.options.UseExponentialLargeBuffer)
             {
                 long pow = 1;
-                while (this.LargeBufferMultiple * pow < requiredSize)
+                while (this.options.LargeBufferMultiple * pow < requiredSize)
                 {
                     pow <<= 1;
                 }
-                return this.LargeBufferMultiple * pow;
+                return this.options.LargeBufferMultiple * pow;
             }
             else
             {
-                return ((requiredSize + this.LargeBufferMultiple - 1) / this.LargeBufferMultiple) * this.LargeBufferMultiple;
+                return ((requiredSize + this.options.LargeBufferMultiple - 1) / this.options.LargeBufferMultiple) * this.options.LargeBufferMultiple;
             }
         }
 
         private bool IsLargeBufferSize(int value)
         {
-            return (value != 0) && (this.UseExponentialLargeBuffer
+            return (value != 0) && (this.options.UseExponentialLargeBuffer
                                         ? (value == RoundToLargeBufferSize(value))
-                                        : (value % this.LargeBufferMultiple) == 0);
+                                        : (value % this.options.LargeBufferMultiple) == 0);
         }
 
         private int GetPoolIndex(long length)
         {
-            if (this.UseExponentialLargeBuffer)
+            if (this.options.UseExponentialLargeBuffer)
             {
                 int index = 0;
-                while ((this.LargeBufferMultiple << index) < length)
+                while ((this.options.LargeBufferMultiple << index) < length)
                 {
                     ++index;
                 }
@@ -511,7 +477,7 @@ namespace Microsoft.IO
             }
             else
             {
-                return (int)(length / this.LargeBufferMultiple - 1);
+                return (int)(length / this.options.LargeBufferMultiple - 1);
             }
         }
 
@@ -522,7 +488,7 @@ namespace Microsoft.IO
         /// <param name="id">Unique stream ID.</param>
         /// <param name="tag">The tag of the stream returning this buffer, for logging if necessary.</param>
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentException"><c>buffer.Length</c> is not a multiple/exponential of <see cref="LargeBufferMultiple"/> (it did not originate from this pool).</exception>
+        /// <exception cref="ArgumentException"><c>buffer.Length</c> is not a multiple/exponential of <see cref="Options.LargeBufferMultiple"/> (it did not originate from this pool).</exception>
         internal void ReturnLargeBuffer(byte[] buffer, Guid id, string? tag)
         {
             if (buffer == null)
@@ -533,15 +499,15 @@ namespace Microsoft.IO
             if (!this.IsLargeBufferSize(buffer.Length))
             {
                 throw new ArgumentException($"{nameof(buffer)} did not originate from this memory manager. The size is not " +
-                                            $"{(this.UseExponentialLargeBuffer ? "an exponential" : "a multiple")} of {this.LargeBufferMultiple}.");
+                                            $"{(this.options.UseExponentialLargeBuffer ? "an exponential" : "a multiple")} of {this.options.LargeBufferMultiple}.");
             }
 
             this.ZeroOutMemoryIfEnabled(buffer);
             var poolIndex = this.GetPoolIndex(buffer.Length);
             if (poolIndex < this.largePools.Length)
             {
-                if ((this.largePools[poolIndex].Count + 1) * buffer.Length <= this.MaximumFreeLargePoolBytes ||
-                    this.MaximumFreeLargePoolBytes == 0)
+                if ((this.largePools[poolIndex].Count + 1) * buffer.Length <= this.options.MaximumLargePoolFreeBytes ||
+                    this.options.MaximumLargePoolFreeBytes == 0)
                 {
                     this.largePools[poolIndex].Push(buffer);
                     Interlocked.Add(ref this.largeBufferFreeSize[poolIndex], buffer.Length);
@@ -553,8 +519,8 @@ namespace Microsoft.IO
             }
             else
             {
-                // This is a non-poolable buffer, but we still want to track its size for inuse
-                // analysis. We have space in the inuse array for this.
+                // This is a non-poolable buffer, but we still want to track its size for in-use
+                // analysis. We have space in the InUse array for this.
                 poolIndex = this.largeBufferInUseSize.Length - 1;
 
                 ReportBufferDiscarded(id, tag, Events.MemoryStreamBufferType.Large, Events.MemoryStreamDiscardReason.TooLarge);
@@ -578,23 +544,23 @@ namespace Microsoft.IO
                 throw new ArgumentNullException(nameof(blocks));
             }
 
-            long bytesToReturn = (long)blocks.Count * (long)this.BlockSize;
+            long bytesToReturn = (long)blocks.Count * (long)this.options.BlockSize;
             Interlocked.Add(ref this.smallPoolInUseSize, -bytesToReturn);
 
             foreach (var block in blocks)
             {
-                if (block == null || block.Length != this.BlockSize)
+                if (block == null || block.Length != this.options.BlockSize)
                 {
-                    throw new ArgumentException($"{nameof(blocks)} contains buffers that are not {nameof(BlockSize)} in length.", nameof(blocks));
+                    throw new ArgumentException($"{nameof(blocks)} contains buffers that are not {nameof(this.options.BlockSize)} in length.", nameof(blocks));
                 }
             }
 
             foreach (var block in blocks)
             {
                 this.ZeroOutMemoryIfEnabled(block);
-                if (this.MaximumFreeSmallPoolBytes == 0 || this.SmallPoolFreeSize < this.MaximumFreeSmallPoolBytes)
+                if (this.options.MaximumSmallPoolFreeBytes == 0 || this.SmallPoolFreeSize < this.options.MaximumSmallPoolFreeBytes)
                 {
-                    Interlocked.Add(ref this.smallPoolFreeSize, this.BlockSize);
+                    Interlocked.Add(ref this.smallPoolFreeSize, this.options.BlockSize);
                     this.smallPool.Push(block);
                 }
                 else
@@ -615,7 +581,7 @@ namespace Microsoft.IO
         /// <exception cref="ArgumentException"><paramref name="block"/> is the wrong size for this memory manager.</exception>
         internal void ReturnBlock(byte[] block, Guid id, string? tag)
         {
-            var bytesToReturn = this.BlockSize;
+            var bytesToReturn = this.options.BlockSize;
             Interlocked.Add(ref this.smallPoolInUseSize, -bytesToReturn);
 
             if (block == null)
@@ -623,14 +589,14 @@ namespace Microsoft.IO
                 throw new ArgumentNullException(nameof(block));
             }
 
-            if (block.Length != this.BlockSize)
+            if (block.Length != this.options.BlockSize)
             {
-                throw new ArgumentException($"{nameof(block)} is not not {nameof(BlockSize)} in length.");
+                throw new ArgumentException($"{nameof(block)} is not not {nameof(this.options.BlockSize)} in length.");
             }
             this.ZeroOutMemoryIfEnabled(block);
-            if (this.MaximumFreeSmallPoolBytes == 0 || this.SmallPoolFreeSize < this.MaximumFreeSmallPoolBytes)
+            if (this.options.MaximumSmallPoolFreeBytes == 0 || this.SmallPoolFreeSize < this.options.MaximumSmallPoolFreeBytes)
             {
-                Interlocked.Add(ref this.smallPoolFreeSize, this.BlockSize);
+                Interlocked.Add(ref this.smallPoolFreeSize, this.options.BlockSize);
                 this.smallPool.Push(block);
             }
             else
@@ -641,7 +607,7 @@ namespace Microsoft.IO
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ZeroOutMemoryIfEnabled(byte[] buffer) {
-            if (this.ZeroOutBuffer) {
+            if (this.options.ZeroOutBuffer) {
 #if NET6_0_OR_GREATER
                 Array.Clear(buffer);
 #else
@@ -714,8 +680,8 @@ namespace Microsoft.IO
 
         internal void ReportStreamOverCapacity(Guid id, string? tag, long requestedCapacity, string? allocationStack)
         {
-            Events.Writer.MemoryStreamOverCapacity(id, tag, requestedCapacity, this.MaximumStreamCapacity, allocationStack);
-            this.StreamOverCapacity?.Invoke(this, new StreamOverCapacityEventArgs(id, tag, requestedCapacity, this.MaximumStreamCapacity, allocationStack));
+            Events.Writer.MemoryStreamOverCapacity(id, tag, requestedCapacity, this.options.MaximumStreamCapacity, allocationStack);
+            this.StreamOverCapacity?.Invoke(this, new StreamOverCapacityEventArgs(id, tag, requestedCapacity, this.options.MaximumStreamCapacity, allocationStack));
         }
 
         internal void ReportUsageReport()
@@ -801,7 +767,7 @@ namespace Microsoft.IO
         /// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
         public RecyclableMemoryStream GetStream(Guid id, string? tag, long requiredSize, bool asContiguousBuffer)
         {
-            if (!asContiguousBuffer || requiredSize <= this.BlockSize)
+            if (!asContiguousBuffer || requiredSize <= this.options.BlockSize)
             {
                 return this.GetStream(id, tag, requiredSize);
             }


### PR DESCRIPTION
This PR creates an `Options` struct to contain all the initial `RecyclableMemoryStreamManager` settings. 

Most of the code changes are just simple refactoring.

A few other things of note:

* I removed most Manager constructors.
* I changed the exception thrown when validating the configuration to be `InvalidOperationException` since it feels like the mistake happens at a remove from the direct constructor call. If you disagree, please yell. I could go either way on this. I'm not sure what the standard approach for this pattern is.
* I added a couple of new tests to improve code coverage of other methods that have been added recently without corresponding tests.
* I fixed some spelling issues in comments, but I decided to stop doing this. I'll deal with nitpicky details like this in a separate PR.

Resolves #256 