### PR TITLE
Add important note to avoid memory leak by wrong usage of the lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class Program
     }
 }
 ```
-| **_IMPORTANT_** | Note that `RecyclableMemoryStreamManager` should be declared once and it will live for the entire process lifetime. It is perfectly fine to use multiple pools if you desire, especially if you want to configure them differently..|
+| **_IMPORTANT_** | Note that `RecyclableMemoryStreamManager` should be declared once and it will live for the entire process lifetime. It is perfectly fine to use multiple pools if you desire, especially if you want to configure them differently.|
 |-|:-|
 
 To facilitate easier debugging, you can optionally provide a string `tag`, which serves as a human-readable identifier for the stream. This can be something like “ClassName.MethodName”, but it can be whatever you want. Each stream also has a GUID to provide absolute identity if needed, but the `tag` is usually sufficient.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ class Program
     }
 }
 ```
-
-Note that `RecyclableMemoryStreamManager` should be declared once and it will live for the entire process lifetime. It is perfectly fine to use multiple pools if you desire, especially if you want to configure them differently.
+| **_IMPORTANT_** | Note that `RecyclableMemoryStreamManager` should be declared once and it will live for the entire process lifetime. It is perfectly fine to use multiple pools if you desire, especially if you want to configure them differently..|
+|-|:-|
 
 To facilitate easier debugging, you can optionally provide a string `tag`, which serves as a human-readable identifier for the stream. This can be something like “ClassName.MethodName”, but it can be whatever you want. Each stream also has a GUID to provide absolute identity if needed, but the `tag` is usually sufficient.
 


### PR DESCRIPTION
Use [RecyclableMemoryStream](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream) was very important to avoid memory leaks on my implementations, but I note that the incorrect usage/instanciation can make an memory leaks in gen2 memory.

To avoid the incorrect usage I've added an enphasys on usage note to avoid wrong implementation.