### PR TITLE
Resolving infinite loop with buffers longer than MaxArrayLength

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -4057,7 +4057,25 @@ namespace Microsoft.IO.UnitTests
                 }
             }
         }
+#pragma warning disable 618 // Timeout is obsolete because it kills the thread, which isn't allowed, but it's still handy
+                            // for tests that are expected to run indefinitely in the failure case.
+        [Test, Timeout(10000)]
+        public void TryGetBuffer_InfiniteLoop_Issue344()
+        {
+            // see https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/issues/344
+            var memMgr = this.GetMemoryManager();
+            var size = 1073741825; // this will cause infinite loop in TryGetBuffer below, 1073741824 works.
+            var bytes = new byte[size];
+            using (var ms = memMgr.GetStream())
+            {
+                ms.Write(bytes, 0, size);
+                bool result = ms.TryGetBuffer(out var segment);
+                Assert.That(result, Is.False);
+                Assert.That(segment, Is.Empty);
+            }
+        }
     }
+#pragma warning restore 618
 
     [TestFixture]
     public sealed class RecyclableMemoryStreamTestsWithPassiveBufferReleaseUsingExponentialLargeBuffer : BaseRecyclableMemoryStreamTestsUsingExponentialLargeBuffer

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -494,7 +494,6 @@ namespace Microsoft.IO
         /// until <see cref="Dispose(bool)"/> is called, but the next time <c>GetBuffer</c> is called, a new buffer from the pool will be required.</remarks>
         /// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
         /// <exception cref="OutOfMemoryException">stream is too large for a contiguous buffer.</exception>
-        /// <exception cref="OverflowException">stream is too long for a contiguous buffer.</exception>
         public override byte[] GetBuffer()
         {
             this.CheckDisposed();

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -494,6 +494,7 @@ namespace Microsoft.IO
         /// until <see cref="Dispose(bool)"/> is called, but the next time <c>GetBuffer</c> is called, a new buffer from the pool will be required.</remarks>
         /// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
         /// <exception cref="OutOfMemoryException">stream is too large for a contiguous buffer.</exception>
+        /// <exception cref="OverflowException">stream is too long for a contiguous buffer.</exception>
         public override byte[] GetBuffer()
         {
             this.CheckDisposed();

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -378,12 +378,12 @@ namespace Microsoft.IO
         /// <exception cref="OutOfMemoryException">Requested array size is larger than the maximum allowed.</exception>
         internal byte[] GetLargeBuffer(long requiredSize, Guid id, string? tag)
         {
+            requiredSize = this.RoundToLargeBufferSize(requiredSize);
+
             if (requiredSize > MaxArrayLength)
             {
-                throw new OutOfMemoryException($"Requested size exceeds maximum array length of {MaxArrayLength}.");
+                throw new OutOfMemoryException($"Required buffer size exceeds maximum array length of {MaxArrayLength}.");
             }
-
-            requiredSize = this.RoundToLargeBufferSize(requiredSize);
 
             var poolIndex = this.GetPoolIndex(requiredSize);
 


### PR DESCRIPTION
Resolves #344 

As reported in #344 , there is an infinite loop that can happen when trying to call `TryGetBuffer` on a very large stream. The correct response is to return `false`.

Specifically, if the stream was longer than 1 GB, and `UseExponentialLargeBuffer` was set to `true`, it would try to pick the next available buffer size, which is 2 GB. Because of the way pool index is calculated, there was an `Int32` underflow, which always compared false to the loop exit condition, thus the infinite loop.

At first, I fixed the `GetPoolIndex` method to do all its math in `long`, but this just pushes the error further down the call stack because you can't actually allocate an array that big. Rather than add new exception conditions in multiple methods, the simplest way to resolve the issue was to just move the existing array length check to be after the rounding step in `GetLargeBuffer`.