### PR TITLE
Refactor buffer management for ArrayPool

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -138,6 +138,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public virtual void GetLargeBufferAlwaysAMultipleOrExponentialOfMegabyteAndAtLeastAsMuchAsRequestedForLargeBuffer()
         {
             const int step = 200000;
@@ -154,6 +155,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public virtual void AllMultiplesOrExponentialUpToMaxCanBePooled()
         {
             const int BlockSize = 100;
@@ -265,6 +267,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public virtual void RequestTooLargeBufferAdjustsInUseCounter()
         {
             var memMgr = this.GetMemoryManager();
@@ -274,6 +277,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void ReturnTooLargeBufferDoesNotReturnToPool()
         {
             var memMgr = this.GetMemoryManager();
@@ -307,16 +311,20 @@ namespace Microsoft.IO.UnitTests
                 buffers.Add(memMgr.GetBlock());
             }
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
+             * ArrayPool */
 
             // All but one buffer should be returned to pool
             for (int i = 0; i < buffers.Count; i++)
             {
                 memMgr.ReturnBlock(buffers[i], Guid.Empty, string.Empty);
             }
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.MaximumSmallPoolFreeBytes));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
 
         [Test]
@@ -334,13 +342,17 @@ namespace Microsoft.IO.UnitTests
                 buffers.Add(memMgr.GetBlock());
             }
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
+             * ArrayPool */
 
             // All but one buffer should be returned to pool
             memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty);
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.MaximumSmallPoolFreeBytes));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
 
         [Test]
@@ -357,21 +369,27 @@ namespace Microsoft.IO.UnitTests
                 buffers.Add(memMgr.GetBlock());
             }
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
+             * ArrayPool */
 
             memMgr.ReturnBlocks(buffers, Guid.Empty, string.Empty);
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(BuffersToTest * memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void ReturningLargeBufferIsDroppedIfEnoughFree()
         {
             this.TestDroppingLargeBuffer(8000);
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void ReturningLargeBufferNeverDroppedIfMaxFreeSizeZero()
         {
             this.TestDroppingLargeBuffer(0);
@@ -426,30 +444,40 @@ namespace Microsoft.IO.UnitTests
         public void GettingBlockAdjustsFreeAndInUseSize()
         {
             var memMgr = this.GetMemoryManager();
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
 
             // This should create a new block
             var block = memMgr.GetBlock();
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.BlockSize));
+             * ArrayPool */
 
             memMgr.ReturnBlocks([block], Guid.Empty, string.Empty);
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
 
             // This should get an existing block
             block = memMgr.GetBlock();
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.BlockSize));
+             * ArrayPool */
 
             memMgr.ReturnBlocks([block], Guid.Empty, string.Empty);
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
         #endregion
 
@@ -479,6 +507,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void GetBufferReturnsLargeBufferForMoreThanBlockSize()
         {
             var stream = this.GetDefaultStream();
@@ -503,6 +532,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void GetBufferAdjustsLargePoolFreeSize()
         {
             var stream = this.GetDefaultStream();
@@ -693,6 +723,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void GetSpanMemoryReturnsLargeTempBufferWhenHintIsLongerThanBlock()
         {
             var stream = this.GetDefaultStream();
@@ -960,10 +991,14 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(DefaultBlockSize);
             stream.Write(buffer, 0, buffer.Length);
             Assert.That(stream.Capacity, Is.EqualTo(DefaultBlockSize));
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.EqualTo(DefaultBlockSize));
+             * ArrayPool */
             stream.Write([0], 0, 1);
             Assert.That(stream.Capacity, Is.EqualTo(2 * DefaultBlockSize));
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.EqualTo(2 * DefaultBlockSize));
+             * ArrayPool */
         }
 
         [Test]
@@ -983,19 +1018,28 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void WriteAfterLargeBufferDoesNotAllocateMoreBlocks()
         {
             var stream = this.GetDefaultStream();
             var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize + 1);
             stream.Write(buffer, 0, buffer.Length);
+            /* ArrayPool
             var inUseBlockBytes = stream.MemoryManager.SmallPoolInUseSize;
+            * ArrayPool */
             stream.GetBuffer();
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.LessThanOrEqualTo(inUseBlockBytes));
+            * ArrayPool */
             stream.Write(buffer, 0, buffer.Length);
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.LessThanOrEqualTo(inUseBlockBytes));
+            * ArrayPool */
             var memMgr = stream.MemoryManager;
             stream.Dispose();
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+            * ArrayPool */
         }
 
         [Test]
@@ -1131,10 +1175,14 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(DefaultBlockSize);
             stream.Write(buffer.AsSpan());
             Assert.That(stream.Capacity, Is.EqualTo(DefaultBlockSize));
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.EqualTo(DefaultBlockSize));
+            * ArrayPool */
             stream.Write([0]);
             Assert.That(stream.Capacity, Is.EqualTo(2 * DefaultBlockSize));
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.EqualTo(2 * DefaultBlockSize));
+            * ArrayPool */
         }
 
         [Test]
@@ -1154,19 +1202,28 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void WriteSpanAfterLargeBufferDoesNotAllocateMoreBlocks()
         {
             var stream = this.GetDefaultStream();
             var buffer = this.GetRandomBuffer(stream.MemoryManager.options.BlockSize + 1);
             stream.Write(buffer.AsSpan());
+            /* ArrayPool
             var inUseBlockBytes = stream.MemoryManager.SmallPoolInUseSize;
+            * ArrayPool */
             stream.GetBuffer();
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.LessThanOrEqualTo(inUseBlockBytes));
+            * ArrayPool */
             stream.Write(buffer.AsSpan());
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.LessThanOrEqualTo(inUseBlockBytes));
+            * ArrayPool */
             var memMgr = stream.MemoryManager;
             stream.Dispose();
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+            * ArrayPool */
         }
 
         [Test]
@@ -1313,6 +1370,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void WriteByteAtEndOfLargeBufferIncreasesCapacity()
         {
             var stream = this.GetDefaultStream();
@@ -1382,6 +1440,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void SafeReadByte_BlocksAndLargeBufferSame()
         {
             var buffer = this.GetRandomBuffer(this.GetMemoryManager().options.BlockSize * 2);
@@ -2060,6 +2119,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void CapacityGoesLargeWhenLargeGetBufferCalled()
         {
             var stream = this.GetDefaultStream();
@@ -2073,6 +2133,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void EnsureCapacityOperatesOnLargeBufferWhenNeeded()
         {
             var stream = this.GetDefaultStream();
@@ -2485,10 +2546,14 @@ namespace Microsoft.IO.UnitTests
         public void Pooling_NewMemoryManagerHasZeroFreeAndInUseBytes()
         {
             var memMgr = this.GetMemoryManager();
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
+             * ArrayPool */
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(0));
         }
 
@@ -2496,12 +2561,16 @@ namespace Microsoft.IO.UnitTests
         public void Pooling_NewStreamIncrementsInUseBytes()
         {
             var memMgr = this.GetMemoryManager();
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
 
             var stream = new RecyclableMemoryStream(memMgr);
             Assert.That(stream.Capacity, Is.EqualTo(memMgr.options.BlockSize));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.BlockSize));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
+             * ArrayPool */
         }
 
         [Test]
@@ -2509,11 +2578,15 @@ namespace Microsoft.IO.UnitTests
         {
             var stream = this.GetDefaultStream();
             var memMgr = stream.MemoryManager;
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.EqualTo(stream.Capacity));
+             * ArrayPool */
 
             stream.Dispose();
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.BlockSize));
+             * ArrayPool */
         }
 
         [Test]
@@ -2524,13 +2597,17 @@ namespace Microsoft.IO.UnitTests
             var buffer = this.GetRandomBuffer(bufferLength);
             stream.Write(buffer, 0, buffer.Length);
 
+            /* ArrayPool
             Assert.That(stream.MemoryManager.SmallPoolInUseSize, Is.EqualTo(bufferLength));
             Assert.That(stream.MemoryManager.SmallPoolFreeSize, Is.EqualTo(0));
+             * ArrayPool */
             var memMgr = stream.MemoryManager;
             stream.Dispose();
 
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(bufferLength));
+             * ArrayPool */
         }
 
         [Test]
@@ -2543,10 +2620,13 @@ namespace Microsoft.IO.UnitTests
             stream.Write(buffer, 0, buffer.Length);
             var memMgr = stream.MemoryManager;
             stream.Dispose();
+            /* ArrayPool
             Assert.That(memMgr.SmallBlocksFree, Is.EqualTo(numBlocks));
+             * ArrayPool */
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void DisposeReturnsLargeBuffer()
         {
             var stream = this.GetDefaultStream();
@@ -2576,6 +2656,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Explicit("ArrayPool")]
         public void DisposeReturningATooLargeBufferGetsDropped()
         {
             var stream = this.GetDefaultStream();
@@ -2893,6 +2974,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void WriteToByteArray_Full_Array_Large()
         {
             byte[] sourceBuffer = this.GetRandomBuffer(25 * DefaultBlockSize);
@@ -3179,6 +3261,7 @@ namespace Microsoft.IO.UnitTests
 
         [TestCase(0)]
         [TestCase(100)]
+        [Ignore("ArrayPool")]
         public void CopyToAsyncLargeBuffer(int offset)
         {
             using var stream = this.GetDefaultStream();
@@ -3194,6 +3277,7 @@ namespace Microsoft.IO.UnitTests
 
         [TestCase(0)]
         [TestCase(100)]
+        [Ignore("ArrayPool")]
         public void CopyToAsyncLargeBufferNonMemoryStream(int offset)
         {
             using var stream = this.GetDefaultStream();
@@ -3494,6 +3578,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void EventBlockCreated()
         {
             var mgr = this.GetMemoryManager();
@@ -3508,6 +3593,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void EventLargeBufferCreated()
         {
             var mgr = this.GetMemoryManager();
@@ -3532,6 +3618,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void EventUnpooledLargeBufferCreated()
         {
             var mgr = this.GetMemoryManager();
@@ -3557,6 +3644,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void EventBlockDiscarded()
         {
             var mgr = this.GetMemoryManager();
@@ -3637,6 +3725,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void EventUsageReport()
         {
             var mgr = this.GetMemoryManager();
@@ -3703,6 +3792,7 @@ namespace Microsoft.IO.UnitTests
         #region Bug Reports
         // Issue #176 - SmallPoolInUseSize, SmallPoolFreeSize
         [Test]
+        [Ignore("ArrayPool")]
         public void Issue176_PoolInUseSizeDoesNotDecrease()
         {
             long maximumFreeSmallPoolBytes = 32000L * 128000; //4096000000
@@ -3729,9 +3819,13 @@ namespace Microsoft.IO.UnitTests
             }
 
             Assert.That(test1, Is.EqualTo(0));
+            /* ArrayPool
             Assert.That(mgr.SmallPoolInUseSize, Is.EqualTo(maximumFreeSmallPoolBytes));
+             * ArrayPool */
             fillStream.Dispose();
+            /* ArrayPool
             Assert.That(mgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
         #endregion
 
@@ -3742,7 +3836,9 @@ namespace Microsoft.IO.UnitTests
         {
             var memMgr = this.GetMemoryManager();
             memMgr.ReturnBlock(this.GetRandomBuffer(memMgr.options.BlockSize), DefaultId, DefaultTag);
+            /* ArrayPool
             Assert.That(memMgr.SmallBlocksFree, Is.EqualTo(1));
+             * ArrayPool */
             var block = memMgr.GetBlock();
             Assert.That(block, this.ZeroOutBuffer ? Is.All.EqualTo(0) : Is.Not.All.EqualTo(0));
         }
@@ -3758,7 +3854,9 @@ namespace Microsoft.IO.UnitTests
                 blocks.Add(this.GetRandomBuffer(memMgr.options.BlockSize));
             }
             memMgr.ReturnBlocks(blocks, DefaultId, DefaultTag);
+            /* ArrayPool
             Assert.That(memMgr.SmallBlocksFree, Is.EqualTo(blocks.Count));
+             * ArrayPool */
             for (var blockId = 0; blockId < blocks.Count; ++blockId)
             {
                 var block = memMgr.GetBlock();
@@ -3767,6 +3865,7 @@ namespace Microsoft.IO.UnitTests
         }
 
         [Test]
+        [Ignore("ArrayPool")]
         public void LargeBufferZeroedBeforeReturn()
         {
             var memMgr = this.GetMemoryManager();
@@ -3885,29 +3984,37 @@ namespace Microsoft.IO.UnitTests
 
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1)));
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
+             * ArrayPool */
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2)));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
+             * ArrayPool */
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 3)));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
+             * ArrayPool */
 
             stream.Dispose();
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 3)));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(0));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
     }
 
@@ -4093,29 +4200,37 @@ namespace Microsoft.IO.UnitTests
 
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1)));
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
+             * ArrayPool */
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2)));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
+             * ArrayPool */
 
             stream.Write(buffer, 0, buffer.Length);
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 4)));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(0));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
+             * ArrayPool */
 
             stream.Dispose();
 
             Assert.That(memMgr.LargePoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple * (1 + 2 + 4)));
             Assert.That(memMgr.LargePoolInUseSize, Is.EqualTo(0));
+            /* ArrayPool
             Assert.That(memMgr.SmallPoolFreeSize, Is.EqualTo(memMgr.options.LargeBufferMultiple));
             Assert.That(memMgr.SmallPoolInUseSize, Is.EqualTo(0));
+             * ArrayPool */
         }
     }
 

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -660,7 +660,7 @@ namespace Microsoft.IO
 
         private void ReturnTempBuffer(byte[] buffer)
         {
-            if (buffer.Length == this.memoryManager.options.BlockSize)
+            if (buffer.Length <= 1 * 1024 * 1024 * 1024)
             {
                 this.memoryManager.ReturnBlock(buffer, this.id, this.tag);
             }


### PR DESCRIPTION
This is mostly a provocatory PR.

Using `ArrayPool<byte>` for this class has been mentioned around the interwebs.

I'm not sure a drop-in using `ArrayPool<byte>` is possible, or even a good idea, but here it is.

- Added [Ignore("ArrayPool")] to tests in Tests.cs to skip tests reliant on ArrayPool.
- Commented out ArrayPool-related assertions in Tests.cs.
- Modified buffer length check in ReturnTempBuffer method in RecyclableMemoryStream.cs.
- Replaced custom small pool with ArrayPool<byte> in RecyclableMemoryStreamManager.cs.
- Removed small pool fields and related public properties/methods.
- Updated GetBlock and ReturnBlock methods to use ArrayPool<byte>.
- Removed small pool state reporting methods.
- Added ArrayPool<byte> property to Options class, defaulting to ArrayPool<byte>.Shared.