### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
-
   - package-ecosystem: 'nuget'
     directory: 'src'
     open-pull-requests-limit: 10
@@ -22,7 +21,6 @@ updates:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
-
   - package-ecosystem: 'nuget'
     directory: 'UnitTests'
     open-pull-requests-limit: 10
@@ -33,5 +31,14 @@ updates:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
-
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
 # Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/