### PR TITLE
Switch MemoryStreamDoubleDispose event level from Critical to Verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ You can optionally configure the `RecyclableStreamManager.ThrowExceptionOnToArra
 | -----|-------|-------------|
 | MemoryStreamCreated | Verbose | Logged every time a stream object is allocated. Fields: `guid`, `tag`, `requestedSize`, `actualSize`. |
 | MemoryStreamDisposed | Verbose | Logged every time a stream object is disposed. Fields: `guid`, `tag`, `allocationStack`, `disposeStack`. |
-| MemoryStreamDoubleDispose | Critical | Logged if a stream is disposed more than once. This indicates a logic error by the user of the stream. Dispose should happen exactly once per stream to avoid resource usage bugs. Fields: `guid`, `tag`, `allocationStack`, `disposeStack1`, `disposeStack2`. |
+| MemoryStreamDoubleDispose | Verbose | Logged if a stream is disposed more than once. This indicates a logic error by the user of the stream. Dispose should happen exactly once per stream to avoid resource usage bugs. Fields: `guid`, `tag`, `allocationStack`, `disposeStack1`, `disposeStack2`. |
 | MemoryStreamFinalized | Error | Logged if a stream has gone out of scope without being disposed. This indicates a resource leak. Fields: `guid`, `tag`, `allocationStack`.|
 | MemoryStreamToArray | Verbose | Logged whenever `ToArray` is called. This indicates a potential problem, as calling `ToArray` goes against the concepts of good memory practice which `RecyclableMemoryStream` is trying to solve. Fields: `guid`, `tag`, `stack`, `size`.|
 | MemoryStreamManagerInitialized| Informational | Logged when the `RecyclableMemoryStreamManager` is initialized. Fields: `blockSize`, `largeBufferMultiple`, `maximumBufferSize`.|

--- a/src/Events.cs
+++ b/src/Events.cs
@@ -110,7 +110,7 @@ namespace Microsoft.IO
             /// <param name="disposeStack1">Call stack of the first dispose.</param>
             /// <param name="disposeStack2">Call stack of the second dispose.</param>
             /// <remarks>Note: Stacks will only be populated if RecyclableMemoryStreamManager.GenerateCallStacks is true.</remarks>
-            [Event(3, Level = EventLevel.Critical)]
+            [Event(3, Level = EventLevel.Verbose)]
             public void MemoryStreamDoubleDispose(Guid guid, string? tag, string? allocationStack, string? disposeStack1,
                                                   string? disposeStack2)
             {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -26,7 +26,6 @@ namespace Microsoft.IO
     using System.Buffers;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Diagnostics.Tracing;
     using System.IO;
     using System.Runtime.CompilerServices;
     using System.Threading;

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -26,6 +26,7 @@ namespace Microsoft.IO
     using System.Buffers;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.Tracing;
     using System.IO;
     using System.Runtime.CompilerServices;
     using System.Threading;
@@ -280,7 +281,7 @@ namespace Microsoft.IO
             if (this.disposed)
             {
                 string? doubleDisposeStack = null;
-                if (this.memoryManager.options.GenerateCallStacks)
+                if (this.memoryManager.GenerateDoubleDisposedStackTrace)
                 {
                     doubleDisposeStack = Environment.StackTrace;
                 }

--- a/src/RecyclableMemoryStreamManager.cs
+++ b/src/RecyclableMemoryStreamManager.cs
@@ -25,6 +25,7 @@ namespace Microsoft.IO
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
     using System.Runtime.CompilerServices;
     using System.Threading;
 
@@ -81,6 +82,13 @@ namespace Microsoft.IO
         private long smallPoolInUseSize;
 
         internal readonly Options options;
+
+        internal bool GenerateDoubleDisposedStackTrace =>
+            this.options.GenerateCallStacks &&
+            (
+                this.StreamDoubleDisposed != null ||
+                Events.Writer.IsEnabled(EventLevel.Verbose, EventKeywords.None)
+            );
 
         /// <summary>
         /// Settings for controlling the behavior of RecyclableMemoryStream


### PR DESCRIPTION
Multiple disposes are common thing in .NET. MSDN says that too:

> [Dispose()](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.component.dispose?view=net-8.0#system-componentmodel-component-dispose) can be called multiple times by other objects. ([link](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.dispose?view=net-8.0#system-io-stream-dispose))

> To help ensure that resources are always cleaned up appropriately, a [Dispose](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable.dispose) method should be idempotent, such that it's callable multiple times without throwing an exception. Furthermore, subsequent invocations of [Dispose](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable.dispose) should do nothing. ([link](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose))

> You should be safe to call it more than once, though you should probably avoid it if you can. (community, [link](https://stackoverflow.com/a/5306896/31094731))

Critical events may spuriously fill up event log with critical events while operations like that aren't even logical error.

So I switched it's event level to `Verbose`. I don't think there are reasons to use Information for events like that, when AspNetCore [disposes streams twice](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/issues/394).

Closes #394
