### PR TITLE
Use trimming-safe EventSourcePrimitives for logging

### DIFF
--- a/src/Events.cs
+++ b/src/Events.cs
@@ -80,7 +80,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(1, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, requestedSize, actualSize });
+#else
                     this.WriteEvent(1, guid, tag ?? string.Empty, requestedSize, actualSize);
+#endif
                 }
             }
 
@@ -97,7 +101,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(2, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, lifetimeMs, allocationStack ?? string.Empty, disposeStack ?? string.Empty });
+#else
                     this.WriteEvent(2, guid, tag ?? string.Empty, lifetimeMs, allocationStack ?? string.Empty, disposeStack ?? string.Empty);
+#endif
                 }
             }
 
@@ -116,8 +124,13 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled())
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(3, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, allocationStack ?? string.Empty,
+                                    disposeStack1 ?? string.Empty, disposeStack2 ?? string.Empty });
+#else
                     this.WriteEvent(3, guid, tag ?? string.Empty, allocationStack ?? string.Empty,
                                     disposeStack1 ?? string.Empty, disposeStack2 ?? string.Empty);
+#endif
                 }
             }
 
@@ -133,7 +146,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled())
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(4, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, allocationStack ?? string.Empty });
+#else
                     this.WriteEvent(4, guid, tag ?? string.Empty, allocationStack ?? string.Empty);
+#endif
                 }
             }
 
@@ -150,7 +167,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(5, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, stack ?? string.Empty, size });
+#else
                     this.WriteEvent(5, guid, tag ?? string.Empty, stack ?? string.Empty, size);
+#endif
                 }
             }
 
@@ -209,7 +230,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(9, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, requiredSize, allocationStack ?? string.Empty });
+#else
                     this.WriteEvent(9, guid, tag ?? string.Empty, requiredSize, allocationStack ?? string.Empty);
+#endif
                 }
             }
 
@@ -232,7 +257,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(10, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, bufferType, reason, smallBlocksFree, smallPoolBytesFree, smallPoolBytesInUse, largeBlocksFree, largePoolBytesFree, largePoolBytesInUse });
+#else
                     this.WriteEvent(10, guid, tag ?? string.Empty, bufferType, reason, smallBlocksFree, smallPoolBytesFree, smallPoolBytesInUse, largeBlocksFree, largePoolBytesFree, largePoolBytesInUse);
+#endif
                 }
             }
 
@@ -250,7 +279,11 @@ namespace Microsoft.IO
             {
                 if (this.IsEnabled())
                 {
+#if NET8_0_OR_GREATER
+                    this.WriteEvent(11, new EventSource.EventSourcePrimitive[] { guid, tag ?? string.Empty, requestedCapacity, maxCapacity, allocationStack ?? string.Empty });
+#else
                     this.WriteEvent(11, guid, tag ?? string.Empty, requestedCapacity, maxCapacity, allocationStack ?? string.Empty);
+#endif
                 }
             }
         }

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.IO</RootNamespace>

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -41,7 +41,11 @@
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     <PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/issues/349 by utilizing .NET 8.0 trimming-safe EventSourcePrimitives for logging.

It replaces #352, which was abandoned by the original author.

This relies on functionality added in net8.0.