### PR TITLE
Update version to 4.0.0-preview, update docs, remove NuGet bug workaround

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Version 4.0.0
 
 **Breaking Changes**
-* Switch `MemoryStreamDoubleDispose` event level from Critical to Verbose [PR #406](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/406)
-* Dropping net6.0 will more easily support trimming [PR #409](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/409)
+* Switch `MemoryStreamDoubleDispose` event level from `Critical` to `Verbose` [PR #406](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/406)
+* Drop net6.0 to simplify support for trimming [PR #409](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/409)
 
 **New Features**
 
@@ -10,6 +10,7 @@
 
 **Other Changes**
 * Readme: Add clarity for the large pool of buffers and the GetBuffer method pertaining to the .NET max array length [PR #370](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/370)
+* Removed workaround for [Nuget packing bug](https://github.com/dotnet/sdk/issues/11105).
 
 # Version 3.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 **Other Changes**
 * Readme: Add clarity for the large pool of buffers and the GetBuffer method pertaining to the .NET max array length [PR #370](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/370)
-* Removed workaround for [Nuget packing bug](https://github.com/dotnet/sdk/issues/11105).
+* Removed workaround for [Nuget packing bug](https://github.com/dotnet/sdk/issues/11105). [PR #445](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/445)
 
 # Version 3.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 # Version 4.0.0
 
 **Breaking Changes**
-* Dropping net6.0 will more easily support trimming [PR #409](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/409)
 * Switch `MemoryStreamDoubleDispose` event level from Critical to Verbose [PR #406](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/406)
+* Dropping net6.0 will more easily support trimming [PR #409](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/409)
+
+**New Features**
+
+* Add trimming support [PR #443](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/443) and utilize `EventSourcePrimtiives` for logging
 
 **Other Changes**
 * Readme: Add clarity for the large pool of buffers and the GetBuffer method pertaining to the .NET max array length [PR #370](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/pull/370)

--- a/generatedocs.cmd
+++ b/generatedocs.cmd
@@ -3,6 +3,16 @@ ECHO ===========================================================
 ECHO Using xmldocmd from https://github.com/ejball/XmlDocMarkdown
 ECHO ===========================================================
 
+where xmldocmd >nul 2>nul
+IF ERRORLEVEL 1 (
+    ECHO xmldocmd not found. Installing...
+    dotnet tool install xmldocmd -g
+    IF ERRORLEVEL 1 (
+        ECHO Failed to install xmldocmd.
+        EXIT /B 1
+    )
+)
+
 del /q /s docs\*
 
 xmldocmd .\src\bin\Release\netstandard2.1\Microsoft.IO.RecyclableMemoryStream.dll .\docs --obsolete --clean

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -56,10 +56,6 @@
     <None Include=".editorconfig" />
   </ItemGroup>
 
-  <!-- Workaround for https://github.com/dotnet/sdk/issues/11105 -->
-  <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)\" Condition="'$(NuGetPackageRoot)' != ''" />
-  </ItemGroup>
   <ItemGroup>
     <EditorConfigFiles Remove=".editorconfig" />
   </ItemGroup>

--- a/src/Microsoft.IO.RecyclableMemoryStream.csproj
+++ b/src/Microsoft.IO.RecyclableMemoryStream.csproj
@@ -7,7 +7,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.IO.RecyclableMemoryStream.xml</DocumentationFile>
     <!-- NuGet properties -->
     <PackageId>Microsoft.IO.RecyclableMemoryStream</PackageId>
-    <PackageVersion>4.0.0-alpha</PackageVersion>
+    <PackageVersion>4.0.0-preview</PackageVersion>
     <Title>Microsoft.IO.RecyclableMemoryStream</Title>
     <Authors>Microsoft</Authors>
     <Description>A pooled MemoryStream allocator to decrease GC load and improve performance on highly scalable systems.</Description>


### PR DESCRIPTION
* Updated version to 4.0.0-preview to match convention of .NET releases.
* Updated CHANGES.md to mention trimming; fixed wording.
* Removed NuGet bug workaround that has been long-fixed.
Resolves #438 