### PR TITLE
Guard finalizer against partial construction

### DIFF
--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -27,6 +27,8 @@ namespace Microsoft.IO.UnitTests
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
@@ -2481,6 +2483,33 @@ namespace Microsoft.IO.UnitTests
         #endregion
 
         #region Dispose and Pooling Tests
+        [TestCase(false, false)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void Dispose_PartiallyConstructedStream_DoesNotThrow(bool assignMemoryManager, bool assignBlocks)
+        {
+            var stream = (RecyclableMemoryStream)RuntimeHelpers.GetUninitializedObject(typeof(RecyclableMemoryStream));
+            try
+            {
+                if (assignMemoryManager)
+                {
+                    typeof(RecyclableMemoryStream).GetField("memoryManager", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(stream, this.GetMemoryManager());
+                }
+
+                if (assignBlocks)
+                {
+                    typeof(RecyclableMemoryStream).GetField("blocks", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(stream, new List<byte[]>());
+                }
+
+                var dispose = typeof(RecyclableMemoryStream).GetMethod("Dispose", BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(bool)], null)!;
+                Assert.DoesNotThrow(() => dispose.Invoke(stream, [false]));
+            }
+            finally
+            {
+                GC.SuppressFinalize(stream);
+            }
+        }
+
         [Test]
         public void Pooling_NewMemoryManagerHasZeroFreeAndInUseBytes()
         {

--- a/src/RecyclableMemoryStream.cs
+++ b/src/RecyclableMemoryStream.cs
@@ -277,6 +277,11 @@ namespace Microsoft.IO
         /// <param name="disposing">Whether we're disposing (true), or being called by the finalizer (false).</param>
         protected override void Dispose(bool disposing)
         {
+            if (this.memoryManager == null || this.blocks == null)
+            {
+                return;
+            }
+
             if (this.disposed)
             {
                 string? doubleDisposeStack = null;


### PR DESCRIPTION
## Summary

Prevent `RecyclableMemoryStream` finalization from throwing when construction fails before required fields are initialized.

## Changes

- Return immediately from `Dispose(bool)` when either `memoryManager` or `blocks` is null.
- Add deterministic regression coverage for uninitialized streams and each meaningful one-field-initialized state.
- Suppress finalization in test cleanup even if an assertion fails.

## Testing

- `dotnet build Microsoft.IO.RecyclableMemoryStream.sln --configuration Debug --no-restore`
- `dotnet test Microsoft.IO.RecyclableMemoryStream.sln --configuration Debug --no-build --no-restore`
- Result: 1,317 passed, 9 skipped, 0 failed.

Fixes #446