### PR TITLE
Update Nuget.config and DependaBot to use safe Microsoft NuGet proxy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
+    registries:
+      - nuget-proxy
   - package-ecosystem: 'nuget'
     directory: 'UnitTests'
     open-pull-requests-limit: 10
@@ -43,4 +45,8 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+registries:
+  nuget-proxy:
+    type: nuget-feed
+    url: "https://packagefeedproxy.microsoft.io/nuget/v3/index.json"
 # Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,8 +13,8 @@
   <packageSources>
     <clear />
     <add
-      key="OSS_All"
-      value="https://api.nuget.org/v3/index.json"
+      key="NugetProxy"
+      value="https://packagefeedproxy.microsoft.io/nuget/v3/index.json"
     />
   </packageSources>
 </configuration>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" PrivateAssets="All" />      
   </ItemGroup>


### PR DESCRIPTION
Safe feeds are now required. The default api.nuget.org feed is no longer accessible on Microsoft corporate devices.

NUnit3TestAdaptor needs to be switched back to 6.2.0 as that's the latest version available in this feed.